### PR TITLE
fix corrupted integer value followed by long string

### DIFF
--- a/singlestoredb/mysql/accel.c
+++ b/singlestoredb/mysql/accel.c
@@ -1283,14 +1283,19 @@ static PyObject *read_row_from_packet(
                 case MYSQL_TYPE_LONG:
                 case MYSQL_TYPE_LONGLONG:
                 case MYSQL_TYPE_INT24:
+                {
+                    char *substr = calloc(out_l + 1, sizeof(char));
+                    memcpy(substr, out, out_l);
                     if (py_state->flags[i] & MYSQL_FLAG_UNSIGNED) {
-                        py_item = PyLong_FromUnsignedLongLong(strtoull(out, &end, 10));
+                        py_item = PyLong_FromUnsignedLongLong(strtoull(substr, NULL, 10));
                     } else {
-                        py_item = PyLong_FromLongLong(strtoll(out, &end, 10));
+                        py_item = PyLong_FromLongLong(strtoll(substr, NULL, 10));
                     }
+                    DESTROY(substr);
+                    out += out_l;
                     if (!py_item) goto error;
                     break;
-
+                }
                 case MYSQL_TYPE_FLOAT:
                 case MYSQL_TYPE_DOUBLE:
                     py_item = PyFloat_FromDouble(strtod(out, &end));

--- a/singlestoredb/mysql/accel.c
+++ b/singlestoredb/mysql/accel.c
@@ -1213,7 +1213,7 @@ static PyObject *read_row_from_packet(
     PyObject *py_result = NULL;
     PyObject *py_item = NULL;
     PyObject *py_str = NULL;
-    char *end = NULL;
+    char end = '\0';
 
     int sign = 1;
     int year = 0;
@@ -1240,7 +1240,7 @@ static PyObject *read_row_from_packet(
     for (unsigned long i = 0; i < py_state->n_cols; i++) {
 
         read_length_coded_string(&data, &data_l, &out, &out_l, &is_null);
-        end = &out[out_l];
+        end = out[out_l];
 
         orig_out = out;
         orig_out_l = out_l;
@@ -1267,10 +1267,6 @@ static PyObject *read_row_from_packet(
 
             // If no converter was passed in, do the default processing.
             else {
-                // Make sure not to overrun
-                char tmp = *end;
-                if (data_l) *end = '\0';
-
                 switch (py_state->type_codes[i]) {
                 case MYSQL_TYPE_NEWDECIMAL:
                 case MYSQL_TYPE_DECIMAL:
@@ -1287,16 +1283,21 @@ static PyObject *read_row_from_packet(
                 case MYSQL_TYPE_LONG:
                 case MYSQL_TYPE_LONGLONG:
                 case MYSQL_TYPE_INT24:
+                    if (data_l) out[out_l] = '\0';
                     if (py_state->flags[i] & MYSQL_FLAG_UNSIGNED) {
                         py_item = PyLong_FromUnsignedLongLong(strtoull(out, NULL, 10));
                     } else {
                         py_item = PyLong_FromLongLong(strtoll(out, NULL, 10));
                     }
+                    if (data_l) out[out_l] = end;
                     if (!py_item) goto error;
                     break;
+
                 case MYSQL_TYPE_FLOAT:
                 case MYSQL_TYPE_DOUBLE:
-                    py_item = PyFloat_FromDouble(strtod(out, &end));
+                    if (data_l) out[out_l] = '\0';
+                    py_item = PyFloat_FromDouble(strtod(out, NULL));
+                    if (data_l) out[out_l] = end;
                     if (!py_item) goto error;
                     break;
 
@@ -1428,8 +1429,10 @@ static PyObject *read_row_from_packet(
                         goto error;
                         break;
                     }
+                    if (data_l) out[out_l] = '\0';
                     year = strtoul(out, NULL, 10);
                     py_item = PyLong_FromLong(year);
+                    if (data_l) out[out_l] = end;
                     if (!py_item) goto error;
                     break;
 
@@ -1469,7 +1472,6 @@ static PyObject *read_row_from_packet(
                                  py_state->type_codes[i], NULL);
                     goto error;
                 }
-                if (data_l) *end = tmp;
             }
         }
 

--- a/singlestoredb/tests/test_basics.py
+++ b/singlestoredb/tests/test_basics.py
@@ -977,10 +977,15 @@ class TestBasics(unittest.TestCase):
         for a, b in zip(s2_out, mydb_out):
             assert a == b, (a, b)
 
-    def test_long_string(self):
+    def test_int_string(self):
         string = 'a' * 48
-        self.cur.execute(f"SELECT 1 AS column_1, '{string}' AS column_2")
+        self.cur.execute(f"SELECT 1, '{string}'")
         self.assertEqual((1, string), self.cur.fetchone())
+
+    def test_double_string(self):
+        string = 'a' * 49
+        self.cur.execute(f"SELECT 1.2 :> DOUBLE, '{string}'")
+        self.assertEqual((1.2, string), self.cur.fetchone())
 
 
 if __name__ == '__main__':

--- a/singlestoredb/tests/test_basics.py
+++ b/singlestoredb/tests/test_basics.py
@@ -977,6 +977,11 @@ class TestBasics(unittest.TestCase):
         for a, b in zip(s2_out, mydb_out):
             assert a == b, (a, b)
 
+    def test_long_string(self):
+        string = 'a' * 48
+        self.cur.execute(f"SELECT 1 AS column_1, '{string}' AS column_2")
+        self.assertEqual((1, string), self.cur.fetchone())
+
 
 if __name__ == '__main__':
     import nose2


### PR DESCRIPTION
Recently I switched from pymysql to singlestoredb and found that integer column values returned from singlestoredb is corrupted when followed by a string column of a certain length.

I added a minimal reproductive as a test case.
Without this change, the test case fails as follows:
```
    def test_long_string(self):
        string = 'a' * 48
        self.cur.execute(f"SELECT 1 AS column_1, '{string}' AS column_2")
>       self.assertEqual((1, string), self.cur.fetchone())
E       AssertionError: Tuples differ: (1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') != (10, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
E
E       First differing element 0:
E       1
E       10
E
E       - (1, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
E       + (10, 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
E       ?   +
```

The root cause is a misuse of `stortoll`/`stotoull`, which reads a consecutive numeric characters, so if a length-encoded string follows and the encoded length can be interpreted as numeric characters, they are read as part of integer value incorrectly. (in the test case, 48 == '0 'in ASCII)

By creating a substring with a provided length, the integer value can be read correctly.