### PR TITLE
add new connection create_database_st method

### DIFF
--- a/singlestoredb/connection.py
+++ b/singlestoredb/connection.py
@@ -1144,6 +1144,19 @@ class Connection(metaclass=abc.ABCMeta):
                     out = [{k: v for k, v in zip(names, row)} for row in out]
             return out
 
+    def create_database_st(self, name: str) -> str:
+        if self.vars['is_shared_tier']:
+            print(
+                'Command ignored. Shared Deployments have a database created by default.',
+            )
+            out = self._iquery('SELECT DATABASE() as CurrentDatabase')
+            return out[0]['CurrentDatabase']
+        else:
+            escaped_name = quote_identifier(name)
+            self._iquery(f'create database {escaped_name}')
+            print(f'Database {name} created')
+            return name
+
     @abc.abstractmethod
     def close(self) -> None:
         """Close the database connection."""

--- a/singlestoredb/tests/test_connection.py
+++ b/singlestoredb/tests/test_connection.py
@@ -53,6 +53,22 @@ class TestConnection(unittest.TestCase):
         dbs = set([x[0] for x in self.cur.fetchall()])
         assert type(self).dbname in dbs, dbs
 
+    def test_connection_create_database_st(self):
+        self.cur.execute('set global is_shared_tier = 0')
+        databae_name_create = 'test_create_st{}'.format(uuid.uuid4()).replace('-', '_')
+
+        current_database_name = self.conn.create_database_st(databae_name_create)
+        assert current_database_name == databae_name_create
+
+        self.cur.execute(f'use {databae_name_create}')
+        self.cur.execute('set global is_shared_tier = 1')
+
+        current_database_name = self.conn.create_database_st('dbname_should_be_ignored')
+        assert current_database_name == databae_name_create
+
+        self.cur.execute('set global is_shared_tier = 0')
+        self.cur.execute(f'drop database {databae_name_create}')
+
     def test_cast_bool_param(self):
         cbp = sc.cast_bool_param
 


### PR DESCRIPTION
Add new method to make it easier to develop notebooks that work against the singlestore cloud free tier. I didn't write any docs, because I don't think this makes sense to expose to anywhere else than to our gallery notebooks

# testing

I ran ` % SINGLESTOREDB_URL=singlestoredb://root:root@localhost:4444 pytest ./singlestoredb/tests/test_connection.py` multiple times