### PR TITLE
Update error handling and memory alloc for mmap approach

### DIFF
--- a/singlestoredb/functions/ext/mmap.py
+++ b/singlestoredb/functions/ext/mmap.py
@@ -163,7 +163,7 @@ def _handle_request(app: Any, connection: Any, client_address: Any) -> None:
             errmsg = f'error occurred in executing function `{name}`: {exc}\n'
             for line in traceback.format_exception(exc):  # type: ignore
                 errmsg += line.rstrip() + '\n'
-            logger.error(errmsg)
+            logger.error(errmsg.rstrip())
             errlen = len(errmsg)
             connection.send(struct.pack(f'<qq{errlen}s', 500, str.encode(errmsg)))
             break


### PR DESCRIPTION
1. The Collocated Service's way of returning an error message is inconsistent with the method used by the Remote Service.  The Remote Service requires the error message to be returned in the response body, while the Collocated Service (currently) requires the error message to be returned on the socket after passing the [status, length] pair.   
2. The Collocated Service will initially receive a response buffer of ~128K, but if it needs to write more, it is responsible for resizing that buffer.