### PR TITLE
HTTP driver timeout bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .ipynb_checkpoints
 .tags
 .vscode
+.venv
 
 ## Compiled source
 *.com

--- a/singlestoredb/http/connection.py
+++ b/singlestoredb/http/connection.py
@@ -386,6 +386,8 @@ class Cursor(connection.Cursor):
         """
         if self._connection is None:
             raise ProgrammingError(errno=2048, msg='Connection is closed.')
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = self._connection.connection_params['connect_timeout']
         return self._connection._post(path, *args, **kwargs)
 
     def callproc(
@@ -1125,9 +1127,6 @@ class Connection(connection.Connection):
             raise InterfaceError(errno=2048, msg='Connection is closed.')
 
         self._sync_connection(kwargs)
-
-        if 'timeout' not in kwargs:
-            kwargs['timeout'] = get_option('connect_timeout')
 
         return self._sess.post(urljoin(self._url, path), *args, **kwargs)
 


### PR DESCRIPTION
### Bug description
- The HTTP drive did not pull the correct value for the integer timeout. The cursor never passed the value to the HTTP connection, so it used default options to set the timeout to 10 seconds -- even if the connection_timeout was set to a different value.

### Effect
- Setting an appropriate timeout for the calls was impossible, so larger queries failed for Data API calls. 

### Fix
- Before Cursor's `_post()` sends the value to the HTTP Connection's `_post()`, we add timeout to the passed kwargs. 
- Removed if-conditional from the HTTP Connection's `_post()` for redundancy. With the current setup, it always pulls the correct value. If connection_timeout is not passed, the Cursor defaults to 10 seconds, so not an issue.

#### Small fix
- Added .venv to gitignore 