### PR TITLE
Enable FusionSQL for jobs

### DIFF
--- a/singlestoredb/fusion/handlers/job.py
+++ b/singlestoredb/fusion/handlers/job.py
@@ -122,8 +122,6 @@ class ScheduleJobHandler(SQLHandler):
         ;
     """
 
-    _enabled = False
-
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
         res.add_field('JobID', result.STRING)
@@ -224,8 +222,6 @@ class RunJobHandler(SQLHandler):
 
     """
 
-    _enabled = False
-
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
         res.add_field('JobID', result.STRING)
@@ -287,8 +283,6 @@ class WaitOnJobsHandler(SQLHandler):
         WAIT ON JOBS 'job1', 'job2' WITH TIMEOUT 60;
 
     """
-
-    _enabled = False
 
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
@@ -358,8 +352,6 @@ class ShowJobsHandler(SQLHandler):
           LIKE 'example_job_name';
 
     """
-
-    _enabled = False
 
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
@@ -492,8 +484,6 @@ class ShowJobExecutionsHandler(SQLHandler):
           EXTENDED;
     """
 
-    _enabled = False
-
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
         res.add_field('ExecutionID', result.STRING)
@@ -564,8 +554,6 @@ class ShowJobParametersHandler(SQLHandler):
         SHOW JOB PARAMETERS FOR 'job1';
     """
 
-    _enabled = False
-
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
         res.add_field('Name', result.STRING)
@@ -605,8 +593,6 @@ class ShowJobRuntimesHandler(SQLHandler):
 
         SHOW JOB RUNTIMES;
     """
-
-    _enabled = False
 
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()
@@ -652,8 +638,6 @@ class DropJobHandler(SQLHandler):
 
         DROP JOBS 'job1', 'job2';
     """
-
-    _enabled = False
 
     def run(self, params: Dict[str, Any]) -> Optional[FusionSQLResult]:
         res = FusionSQLResult()


### PR DESCRIPTION
This MR enables all FusionSQL commands for Job Service, so we no longer have to set the `SINGLESTOREDB_FUSION_ENABLE_HIDDEN` env var to use them.