### PR TITLE
Add option to pass tls sni servername

### DIFF
--- a/singlestoredb/config.py
+++ b/singlestoredb/config.py
@@ -135,6 +135,12 @@ register_option(
 )
 
 register_option(
+    'tls_sni_servername', 'str', check_str, None,
+    'Sets TLS SNI servername',
+    environ='SINGLESTOREDB_TLS_SNI_SERVERNAME',
+)
+
+register_option(
     'ssl_disabled', 'bool', check_bool, False,
     'Disable SSL usage',
     environ='SINGLESTOREDB_SSL_DISABLED',

--- a/singlestoredb/connection.py
+++ b/singlestoredb/connection.py
@@ -1298,6 +1298,7 @@ def connect(
     ssl_key: Optional[str] = None, ssl_cert: Optional[str] = None,
     ssl_ca: Optional[str] = None, ssl_disabled: Optional[bool] = None,
     ssl_cipher: Optional[str] = None, ssl_verify_cert: Optional[bool] = None,
+    tls_sni_servername: Optional[str] = None,
     ssl_verify_identity: Optional[bool] = None,
     conv: Optional[Dict[int, Callable[..., Any]]] = None,
     credential_type: Optional[str] = None,


### PR DESCRIPTION
Adds option `tls_sni_servername`  to set different server hostname. This is need in order to connect to S2DB using SNI proxy.

cc: @ricardoasmarques