### PR TITLE
Add Wrapper for ChatOpenAI and OpenAIEmbeddings

### DIFF
--- a/singlestoredb/ai/__init__.py
+++ b/singlestoredb/ai/__init__.py
@@ -1,1 +1,2 @@
+from .chat import SingleStoreChatOpenAI  # noqa: F401
 from .embeddings import SingleStoreEmbeddings  # noqa: F401

--- a/singlestoredb/ai/chat.py
+++ b/singlestoredb/ai/chat.py
@@ -4,7 +4,7 @@ from typing import Any
 from singlestoredb.fusion.handlers.utils import get_workspace_manager
 
 try:
-    from langchain_openai import OpenAIEmbeddings
+    from langchain_openai import ChatOpenAI
 except ImportError:
     raise ImportError(
         'Could not import langchain_openai python package. '
@@ -12,8 +12,7 @@ except ImportError:
     )
 
 
-class SingleStoreEmbeddings(OpenAIEmbeddings):
-
+class SingleStoreChatOpenAI(ChatOpenAI):
     def __init__(self, model_name: str, **kwargs: Any):
         inference_api_manger = (
             get_workspace_manager().organizations.current.inference_apis

--- a/singlestoredb/management/inference_api.py
+++ b/singlestoredb/management/inference_api.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""SingleStoreDB Cloud Inference API."""
+import os
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+from .utils import vars_to_str
+from singlestoredb.exceptions import ManagementError
+from singlestoredb.management.manager import Manager
+
+
+class InferenceAPIInfo(object):
+    """
+    Inference API definition.
+
+    This object is not directly instantiated. It is used in results
+    of API calls on the :class:`InferenceAPIManager`. See :meth:`InferenceAPIManager.get`.
+    """
+
+    service_id: str
+    model_name: str
+    name: str
+    connection_url: str
+    project_id: str
+
+    def __init__(
+        self,
+        service_id: str,
+        model_name: str,
+        name: str,
+        connection_url: str,
+        project_id: str,
+    ):
+        self.service_id = service_id
+        self.connection_url = connection_url
+        self.model_name = model_name
+        self.name = name
+        self.project_id = project_id
+
+    @classmethod
+    def from_dict(
+        cls,
+        obj: Dict[str, Any],
+    ) -> 'InferenceAPIInfo':
+        """
+        Construct a Inference API from a dictionary of values.
+
+        Parameters
+        ----------
+        obj : dict
+            Dictionary of values
+
+        Returns
+        -------
+        :class:`Job`
+
+        """
+        out = cls(
+            service_id=obj['serviceID'],
+            project_id=obj['projectID'],
+            model_name=obj['modelName'],
+            name=obj['name'],
+            connection_url=obj['connectionURL'],
+        )
+        return out
+
+    def __str__(self) -> str:
+        """Return string representation."""
+        return vars_to_str(self)
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return str(self)
+
+
+class InferenceAPIManager(object):
+    """
+    SingleStoreDB Inference APIs manager.
+
+    This class should be instantiated using :attr:`Organization.inference_apis`.
+
+    Parameters
+    ----------
+    manager : InferenceAPIManager, optional
+        The InferenceAPIManager the InferenceAPIManager belongs to
+
+    See Also
+    --------
+    :attr:`InferenceAPI`
+    """
+
+    def __init__(self, manager: Optional[Manager]):
+        self._manager = manager
+        self.project_id = os.environ.get('SINGLESTOREDB_PROJECT')
+
+    def get(self, model_name: str) -> InferenceAPIInfo:
+        if self._manager is None:
+            raise ManagementError(msg='Manager not initialized')
+        res = self._manager._get(f'inferenceapis/{self.project_id}/{model_name}').json()
+        return InferenceAPIInfo.from_dict(res)

--- a/singlestoredb/management/organization.py
+++ b/singlestoredb/management/organization.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import Union
 
 from ..exceptions import ManagementError
+from .inference_api import InferenceAPIManager
 from .job import JobsManager
 from .manager import Manager
 from .utils import vars_to_str
@@ -207,3 +208,19 @@ class Organization(object):
         :class:`JobsManager`
         """
         return JobsManager(self._manager)
+
+    @property
+    def inference_apis(self) -> InferenceAPIManager:
+        """
+        Retrieve a SingleStoreDB inference api manager.
+
+        Parameters
+        ----------
+        manager : WorkspaceManager, optional
+            The WorkspaceManager the InferenceAPIManager belongs to
+
+        Returns
+        -------
+        :class:`InferenceAPIManager`
+        """
+        return InferenceAPIManager(self._manager)


### PR DESCRIPTION
Adds a SingleStore wrapper for `ChatOpenAI` and `OpenAIEmbeddings` which sets `base_url` and `api_key`

cc: @ricardoasmarques @mgiannakopoulos @vsharma-code @srinathnarayanan 