### PR TITLE
feat(manager): add api versioning to manager

### DIFF
--- a/singlestoredb/management/cluster.py
+++ b/singlestoredb/management/cluster.py
@@ -440,7 +440,7 @@ def manage_cluster(
     access_token : str, optional
         The API key or other access token for the cluster management API
     version : str, optional
-        Version of the API to use
+        Version of the API to use (default: 'v1')
     base_url : str, optional
         Base URL of the cluster management API
     organization_id: str, optional

--- a/singlestoredb/management/files.py
+++ b/singlestoredb/management/files.py
@@ -534,7 +534,7 @@ def manage_files(
     access_token : str, optional
         The API key or other access token for the files management API
     version : str, optional
-        Version of the API to use
+        Version of the API to use (default: 'v1')
     base_url : str, optional
         Base URL of the files management API
     organization_id : str, optional

--- a/singlestoredb/management/manager.py
+++ b/singlestoredb/management/manager.py
@@ -149,7 +149,7 @@ class Manager(object):
             self._sess.headers.update({'Authorization': f'Bearer {get_token()}'})
 
         # Combine version and path
-        versioned_path = f'{self._version}/{path}'
+        versioned_path = f'{self.version}/{path}'
 
         return getattr(self._sess, method.lower())(
             urljoin(self._base_url, versioned_path), *args, **kwargs,

--- a/singlestoredb/management/region.py
+++ b/singlestoredb/management/region.py
@@ -143,7 +143,7 @@ def manage_regions(
     access_token : str, optional
         The API key or other access token for the workspace management API
     version : str, optional
-        Version of the API to use
+        Version of the API to use (default: 'v1')
     base_url : str, optional
         Base URL of the workspace management API
 

--- a/singlestoredb/management/workspace.py
+++ b/singlestoredb/management/workspace.py
@@ -1978,7 +1978,7 @@ def manage_workspaces(
     access_token : str, optional
         The API key or other access token for the workspace management API
     version : str, optional
-        Version of the API to use
+        Version of the API to use (default is 'v1')
     base_url : str, optional
         Base URL of the workspace management API
     organization_id : str, optional


### PR DESCRIPTION
There are some management api endpoints that have a different api version (v2). To handle these cases, we created a new generic attribute of the Manager class that copies the manager and changes the api version