### PR TITLE
fix(requests): fix request params replacement

### DIFF
--- a/singlestoredb/management/manager.py
+++ b/singlestoredb/management/manager.py
@@ -148,7 +148,7 @@ class Manager(object):
 
         """
         if self._params:
-            kwargs['params'] = self._params
+            kwargs.setdefault('params', {}).update(self._params)
         set_organization(kwargs)
         return self._check(self._doit('get', path, *args, **kwargs), path, kwargs)
 
@@ -171,7 +171,7 @@ class Manager(object):
 
         """
         if self._params:
-            kwargs['params'] = self._params
+            kwargs.setdefault('params', {}).update(self._params)
         set_organization(kwargs)
         return self._check(self._doit('post', path, *args, **kwargs), path, kwargs)
 
@@ -194,7 +194,7 @@ class Manager(object):
 
         """
         if self._params:
-            kwargs['params'] = self._params
+            kwargs.setdefault('params', {}).update(self._params)
         set_organization(kwargs)
         return self._check(self._doit('put', path, *args, **kwargs), path, kwargs)
 
@@ -217,7 +217,7 @@ class Manager(object):
 
         """
         if self._params:
-            kwargs['params'] = self._params
+            kwargs.setdefault('params', {}).update(self._params)
         set_organization(kwargs)
         return self._check(self._doit('delete', path, *args, **kwargs), path, kwargs)
 
@@ -240,7 +240,7 @@ class Manager(object):
 
         """
         if self._params:
-            kwargs['params'] = self._params
+            kwargs.setdefault('params', {}).update(self._params)
         set_organization(kwargs)
         return self._check(self._doit('patch', path, *args, **kwargs), path, kwargs)
 


### PR DESCRIPTION
This PR fixes a bug where query parameters passed to the request functions (_get, _post, etc...) via kwargs were unintentionally overridden when self._params was set (for example `organizationID`). As a result, any params the caller provided (e.g., params={'metadata': 1} in https://github.com/singlestore-labs/singlestoredb-python/blob/61c22a0d98d65ceb2f4db1b9d90c047c0fef36e1/singlestoredb/management/files.py#L842) were silently ignored, and did not appear in the final request URL.

