### PR TITLE
Enforce function definition limits

### DIFF
--- a/singlestoredb/apps/_python_udfs.py
+++ b/singlestoredb/apps/_python_udfs.py
@@ -50,10 +50,10 @@ async def run_udf_app(
     app = Application(url=base_url, app_mode='managed', name_suffix=udf_suffix)
 
     if not app.endpoints:
-        raise ValueError("You must define at least one function.")
+        raise ValueError('You must define at least one function.')
     if len(app.endpoints) > MAX_UDFS_LIMIT:
         raise ValueError(
-            f"You can only define a maximum of {MAX_UDFS_LIMIT} functions."
+            f"You can only define a maximum of {MAX_UDFS_LIMIT} functions.",
         )
 
     config = uvicorn.Config(

--- a/singlestoredb/apps/_python_udfs.py
+++ b/singlestoredb/apps/_python_udfs.py
@@ -13,6 +13,8 @@ if typing.TYPE_CHECKING:
 # Keep track of currently running server
 _running_server: 'typing.Optional[AwaitableUvicornServer]' = None
 
+# Maximum number of UDFs allowed
+MAX_UDFS_LIMIT = 10
 
 async def run_udf_app(
     log_level: str = 'error',
@@ -45,6 +47,11 @@ async def run_udf_app(
     if app_config.running_interactively:
         udf_suffix = '_test'
     app = Application(url=base_url, app_mode='managed', name_suffix=udf_suffix)
+
+    if not app.endpoints:
+        raise ValueError("You must define at least one function.")
+    if len(app.endpoints) > MAX_UDFS_LIMIT:
+        raise ValueError(f"You can only define a maximum of {MAX_UDFS_LIMIT} functions.")
 
     config = uvicorn.Config(
         app,

--- a/singlestoredb/apps/_python_udfs.py
+++ b/singlestoredb/apps/_python_udfs.py
@@ -16,6 +16,7 @@ _running_server: 'typing.Optional[AwaitableUvicornServer]' = None
 # Maximum number of UDFs allowed
 MAX_UDFS_LIMIT = 10
 
+
 async def run_udf_app(
     log_level: str = 'error',
     kill_existing_app_server: bool = True,
@@ -51,7 +52,9 @@ async def run_udf_app(
     if not app.endpoints:
         raise ValueError("You must define at least one function.")
     if len(app.endpoints) > MAX_UDFS_LIMIT:
-        raise ValueError(f"You can only define a maximum of {MAX_UDFS_LIMIT} functions.")
+        raise ValueError(
+            f"You can only define a maximum of {MAX_UDFS_LIMIT} functions."
+        )
 
     config = uvicorn.Config(
         app,

--- a/singlestoredb/apps/_python_udfs.py
+++ b/singlestoredb/apps/_python_udfs.py
@@ -53,7 +53,7 @@ async def run_udf_app(
         raise ValueError('You must define at least one function.')
     if len(app.endpoints) > MAX_UDFS_LIMIT:
         raise ValueError(
-            f"You can only define a maximum of {MAX_UDFS_LIMIT} functions.",
+            f'You can only define a maximum of {MAX_UDFS_LIMIT} functions.',
         )
 
     config = uvicorn.Config(


### PR DESCRIPTION
This PR enforces minimum and maximum limits for Python UDFs.

It defines a `MAX_UDFS_LIMIT` global variable for the maximum limit, we might want to make it more configurable in future.

These limits are checked within `run_udf_app` function before starting the server.