### PR TITLE
fix: Fix object has no attribute `servers` for udfs

### DIFF
--- a/singlestoredb/apps/_python_udfs.py
+++ b/singlestoredb/apps/_python_udfs.py
@@ -52,12 +52,12 @@ async def run_udf_app(
         port=app_config.listen_port,
         log_level=log_level,
     )
-    _running_server = AwaitableUvicornServer(config)
 
     # Register the functions only if the app is running interactively.
     if app_config.running_interactively:
         app.register_functions(replace=True)
 
+    _running_server = AwaitableUvicornServer(config)
     asyncio.create_task(_running_server.serve())
     await _running_server.wait_for_startup()
 

--- a/singlestoredb/apps/_stdout_supress.py
+++ b/singlestoredb/apps/_stdout_supress.py
@@ -9,7 +9,7 @@ class StdoutSuppressor:
     This should not be used for asynchronous or threaded executions.
 
     ```py
-    with Supressor():
+    with StdoutSupressor():
         print("This won't be printed")
     ```
 

--- a/singlestoredb/apps/_uvicorn_util.py
+++ b/singlestoredb/apps/_uvicorn_util.py
@@ -30,3 +30,7 @@ class AwaitableUvicornServer(uvicorn.Server):
 
     async def wait_for_startup(self) -> None:
         await self._startup_future
+
+    async def shutdown(self, sockets: Optional[list[socket.socket]] = None) -> None:
+        if self.started:
+            await super().shutdown(sockets)


### PR DESCRIPTION
We shut down a previously started server if present when starting new python udf server. 

```python3
    _running_server = AwaitableUvicornServer(config) # <---- we have tracked the server
    # Register the functions only if the app is running interactively.
    if app_config.running_interactively:
        app.register_functions(replace=True) # <----- Something goes wrong here


    asyncio.create_task(_running_server.serve()) # <---- server is started here
    await _running_server.wait_for_startup()
```

In above code if `register_functions` fails we will be in a state where we think we have a running server but we don't. This results in unvicorn throwing an error `has no attribute 'servers'` when we try shutdown this not running server.


I have made two changes to fix this (any one would resolve our issue):
1. Only track `_running_server` after the function has been registered
2. Run `shutdown` only after verifying that previous server actually started


# Test
Tested by running [this notebook](https://portal.singlestore.com/organizations/6179a453-89bc-4341-8885-287ada1e5dd8/develop/notebook/e003a14c-b9a6-4630-811c-0a13e04a568b%2F_internal-s2-files%2Ff620f4b9-7a66-4996-a0ec-c7283dab13d5?workloadType=InteractiveNotebook&connectionID=ba623372-2e3b-422b-9c04-60d155ac7a72).
An easy way to make `register_functions` fail is to not select a database.