### PR TITLE
fix: Impersonating JWT (obo) header not propagated correctly for OpenAI requests.

### DIFF
--- a/singlestoredb/ai/chat.py
+++ b/singlestoredb/ai/chat.py
@@ -32,10 +32,9 @@ from botocore.config import Config
 
 def SingleStoreChatFactory(
     model_name: str,
-    api_key: Optional[Union[Optional[str], Callable[[], Optional[str]]]] = None,
+    api_key: Optional[str] = None,
     streaming: bool = True,
     http_client: Optional[httpx.Client] = None,
-    obo_token: Optional[Union[Optional[str], Callable[[], Optional[str]]]] = None,
     obo_token_getter: Optional[Callable[[], Optional[str]]] = None,
     base_url: Optional[str] = None,
     hosting_platform: Optional[str] = None,
@@ -43,24 +42,6 @@ def SingleStoreChatFactory(
 ) -> Union[ChatOpenAI, ChatBedrockConverse]:
     """Return a chat model instance (ChatOpenAI or ChatBedrockConverse).
     """
-    # Handle api_key and obo_token as callable functions
-    if callable(api_key):
-        api_key_getter_fn = api_key
-    else:
-        def api_key_getter_fn() -> Optional[str]:
-            if api_key is None:
-                return os.environ.get('SINGLESTOREDB_USER_TOKEN')
-            return api_key
-
-    if obo_token_getter is not None:
-        obo_token_getter_fn = obo_token_getter
-    else:
-        if callable(obo_token):
-            obo_token_getter_fn = obo_token
-        else:
-            def obo_token_getter_fn() -> Optional[str]:
-                return obo_token
-
     # handle model info
     if base_url is None:
         base_url = os.environ.get('SINGLESTOREDB_INFERENCE_API_BASE_URL')
@@ -126,12 +107,12 @@ def SingleStoreChatFactory(
 
         def _inject_headers(request: Any, **_ignored: Any) -> None:
             """Inject dynamic auth/OBO headers prior to Bedrock sending."""
-            if api_key_getter_fn is not None:
-                token_val = api_key_getter_fn()
-                if token_val:
-                    request.headers['Authorization'] = f'Bearer {token_val}'
-            if obo_token_getter_fn is not None:
-                obo_val = obo_token_getter_fn()
+            token_env_val = os.environ.get('SINGLESTOREDB_USER_TOKEN')
+            token_val = api_key if api_key is not None else token_env_val
+            if token_val:
+                request.headers['Authorization'] = f'Bearer {token_val}'
+            if obo_token_getter is not None:
+                obo_val = obo_token_getter()
                 if obo_val:
                     request.headers['X-S2-OBO'] = obo_val
             request.headers.pop('X-Amz-Date', None)
@@ -167,7 +148,8 @@ def SingleStoreChatFactory(
         )
 
     # OpenAI / Azure OpenAI path
-    token = api_key_getter_fn()
+    token_env = os.environ.get('SINGLESTOREDB_USER_TOKEN')
+    token = api_key if api_key is not None else token_env
 
     openai_kwargs = dict(
         base_url=info.connection_url,


### PR DESCRIPTION
WIth this change we:

- Revert the ability for OpenAI clients to dynamically pass api_token and obo_token values (we can achieve this by providing a custom `http_client` in the factory methods and ensuring that we provide the bearer auth token as another header compared to the default `Authorization` header [change will happen in a subsequent PR and once Unified Model Gateway accounts for this fact as well]).
- `http_client` parameter won't be in a deprecated state anymore. We will continue using it as expected.
- Removal of `timeout` parameter, we get the values for timeouts from the `http_client` parameter.
- Initialization for OpenAI clients follows the old pattern not breaking the Impersonating JWT (OBO token). The current implementation is not working because OpenAI re-writes all the header values when we try to modify the `Authorization` header as well.