### PR TITLE
Add delete-function support to WASM plugin interface

### DIFF
--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -90,10 +90,10 @@ def _handle_register(
     except json.JSONDecodeError as e:
         return ControlResult(ok=False, data=f'Invalid JSON: {e}')
 
-    function_name = body.get('function_name')
+    function_name = body.get('name')
     if not function_name:
         return ControlResult(
-            ok=False, data='Missing required field: function_name',
+            ok=False, data='Missing required field: name',
         )
 
     args = body.get('args')
@@ -158,10 +158,10 @@ def _handle_delete(
     except json.JSONDecodeError as e:
         return ControlResult(ok=False, data=f'Invalid JSON: {e}')
 
-    function_name = body.get('function_name')
+    function_name = body.get('name')
     if not function_name:
         return ControlResult(
-            ok=False, data='Missing required field: function_name',
+            ok=False, data='Missing required field: name',
         )
 
     try:

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -421,6 +421,27 @@ class FunctionRegistry:
         )
         return new_names
 
+    def delete_function(self, signature_json: str) -> None:
+        """Delete a dynamically registered function by its signature.
+
+        Args:
+            signature_json: JSON object matching the describe-functions
+                element schema (must contain a 'name' field). Currently
+                only the name is used for matching.
+
+        Raises ValueError if the function does not exist.
+        """
+        sig = json.loads(signature_json)
+        name = sig.get('name')
+        if not name:
+            raise ValueError(
+                'signature JSON must contain a "name" field',
+            )
+        if name not in self.functions:
+            raise ValueError(f"Function '{name}' not found")
+        del self.functions[name]
+        logger.info(f'delete_function: removed {name!r}')
+
     def _register_function(
         self,
         func: Callable[..., Any],

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -392,9 +392,14 @@ class FunctionRegistry:
                 f'(use replace=true to overwrite)',
             )
 
+        if func_name in self._base_function_names:
+            raise ValueError(
+                f"Cannot replace '{func_name}': "
+                f'not a dynamically registered function',
+            )
+
         if replace and func_name in self.functions:
             del self.functions[func_name]
-            self._base_function_names.discard(func_name)
 
         full_code = self._build_python_code(sig, code)
 

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -453,6 +453,10 @@ class FunctionRegistry:
                 f"Cannot delete '{name}': not a dynamically registered function",
             )
         del self.functions[name]
+        dyn_module_name = 'singlestoredb.functions.ext.plugin._dynamic'
+        dyn_module = sys.modules.get(dyn_module_name)
+        if dyn_module is not None and hasattr(dyn_module, name):
+            delattr(dyn_module, name)
         logger.info(f'delete_function: removed {name!r}')
 
     def _register_function(

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -394,6 +394,7 @@ class FunctionRegistry:
 
         if replace and func_name in self.functions:
             del self.functions[func_name]
+            self._base_function_names.discard(func_name)
 
         full_code = self._build_python_code(sig, code)
 

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -146,6 +146,7 @@ class FunctionRegistry:
 
     def __init__(self) -> None:
         self.functions: Dict[str, Dict[str, Any]] = {}
+        self._base_function_names: set[str] = set()
 
     def initialize(self, plugin_module: Any = None) -> None:
         """Initialize and discover UDF functions from loaded modules.
@@ -170,6 +171,8 @@ class FunctionRegistry:
                 )
         else:
             self._discover_udf_functions()
+
+        self._base_function_names = set(self.functions.keys())
 
     @staticmethod
     def _is_stdlib_or_infra(mod_name: str, mod_file: str) -> bool:
@@ -439,6 +442,10 @@ class FunctionRegistry:
             )
         if name not in self.functions:
             raise ValueError(f"Function '{name}' not found")
+        if name in self._base_function_names:
+            raise ValueError(
+                f"Cannot delete '{name}': not a dynamically registered function",
+            )
         del self.functions[name]
         logger.info(f'delete_function: removed {name!r}')
 

--- a/singlestoredb/functions/ext/plugin/server.py
+++ b/singlestoredb/functions/ext/plugin/server.py
@@ -195,6 +195,14 @@ class SharedRegistry:
         if self._base_registry is not None:
             registry.functions = dict(self._base_registry.functions)
             registry._base_function_names = set(self._base_registry._base_function_names)
+        # Clear the shared dynamic module so only current code blocks
+        # contribute functions (prevents deleted UDFs from reappearing)
+        dyn_module_name = 'singlestoredb.functions.ext.plugin._dynamic'
+        if dyn_module_name in sys.modules:
+            dyn = sys.modules[dyn_module_name]
+            for attr in [a for a in dir(dyn) if not a.startswith('_')]:
+                delattr(dyn, attr)
+
         # Replay code blocks
         for sig_json, code, replace in self._code_blocks:
             registry.create_function(sig_json, code, replace)

--- a/singlestoredb/functions/ext/plugin/server.py
+++ b/singlestoredb/functions/ext/plugin/server.py
@@ -194,7 +194,10 @@ class SharedRegistry:
         # Copy base functions
         if self._base_registry is not None:
             registry.functions = dict(self._base_registry.functions)
-            registry._base_function_names = set(self._base_registry._base_function_names)
+            registry._base_function_names = (
+                set(self._base_registry._base_function_names)
+                | set(self._base_registry.functions.keys())
+            )
         # Clear the shared dynamic module so only current code blocks
         # contribute functions (prevents deleted UDFs from reappearing)
         dyn_module_name = 'singlestoredb.functions.ext.plugin._dynamic'

--- a/singlestoredb/functions/ext/plugin/server.py
+++ b/singlestoredb/functions/ext/plugin/server.py
@@ -18,6 +18,7 @@ import struct
 import sys
 import threading
 import traceback
+import types
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from typing import Dict
@@ -198,13 +199,12 @@ class SharedRegistry:
                 set(self._base_registry._base_function_names)
                 | set(self._base_registry.functions.keys())
             )
-        # Clear the shared dynamic module so only current code blocks
-        # contribute functions (prevents deleted UDFs from reappearing)
+        # Swap in a fresh dynamic module so replayed code blocks get a clean
+        # namespace. Existing function objects keep their original __globals__.
         dyn_module_name = 'singlestoredb.functions.ext.plugin._dynamic'
-        if dyn_module_name in sys.modules:
-            dyn = sys.modules[dyn_module_name]
-            for attr in [a for a in dir(dyn) if not a.startswith('_')]:
-                delattr(dyn, attr)
+        fresh_dyn = types.ModuleType(dyn_module_name)
+        fresh_dyn.__file__ = f'<{dyn_module_name}>'
+        sys.modules[dyn_module_name] = fresh_dyn
 
         # Replay code blocks
         for sig_json, code, replace in self._code_blocks:

--- a/singlestoredb/functions/ext/plugin/server.py
+++ b/singlestoredb/functions/ext/plugin/server.py
@@ -194,6 +194,7 @@ class SharedRegistry:
         # Copy base functions
         if self._base_registry is not None:
             registry.functions = dict(self._base_registry.functions)
+            registry._base_function_names = set(self._base_registry._base_function_names)
         # Replay code blocks
         for sig_json, code, replace in self._code_blocks:
             registry.create_function(sig_json, code, replace)

--- a/singlestoredb/functions/ext/plugin/wasm.py
+++ b/singlestoredb/functions/ext/plugin/wasm.py
@@ -70,3 +70,11 @@ class Plugin:
         except Exception as e:
             tb = traceback.format_exc()
             raise RuntimeError(f'{e}\n{tb}')
+
+    def delete_function(self, signature: str) -> None:
+        """Delete a dynamically registered function by its signature."""
+        try:
+            _registry.delete_function(signature)
+        except Exception as e:
+            tb = traceback.format_exc()
+            raise RuntimeError(f'{e}\n{tb}')

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -241,6 +241,34 @@ class TestControlSignalDispatch(unittest.TestCase):
         shared.delete_function.assert_called_once_with('my_func')
 
 
+class TestFunctionRegistryDeleteGuard(unittest.TestCase):
+    """Unit tests for FunctionRegistry.delete_function base-function guard."""
+
+    def _make_registry_with_base(self):
+        reg = FunctionRegistry()
+        reg.functions = {'base_fn': {'signature': {}, 'func': lambda: None}}
+        reg._base_function_names = {'base_fn'}
+        return reg
+
+    def test_delete_base_function_rejected(self):
+        reg = self._make_registry_with_base()
+        with self.assertRaises(ValueError) as ctx:
+            reg.delete_function(json.dumps({'name': 'base_fn'}))
+        assert 'not a dynamically registered function' in str(ctx.exception)
+
+    def test_delete_dynamic_function_allowed(self):
+        reg = self._make_registry_with_base()
+        reg.functions['dyn_fn'] = {'signature': {}, 'func': lambda: None}
+        reg.delete_function(json.dumps({'name': 'dyn_fn'}))
+        assert 'dyn_fn' not in reg.functions
+
+    def test_delete_nonexistent_raises(self):
+        reg = self._make_registry_with_base()
+        with self.assertRaises(ValueError) as ctx:
+            reg.delete_function(json.dumps({'name': 'ghost'}))
+        assert 'not found' in str(ctx.exception)
+
+
 class TestDeleteFunctionIntegration(unittest.TestCase):
     """Integration tests for @@delete using a real SharedRegistry."""
 

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -268,16 +268,16 @@ class TestFunctionRegistryDeleteGuard(unittest.TestCase):
             reg.delete_function(json.dumps({'name': 'ghost'}))
         assert 'not found' in str(ctx.exception)
 
-    def test_replace_base_then_delete_allowed(self):
+    def test_replace_base_function_rejected(self):
         reg = self._make_registry_with_base()
         sig = json.dumps({
             'name': 'base_fn',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
         })
-        reg.create_function(sig, 'return x + 1', replace=True)
-        reg.delete_function(json.dumps({'name': 'base_fn'}))
-        assert 'base_fn' not in reg.functions
+        with self.assertRaises(ValueError) as ctx:
+            reg.create_function(sig, 'return x + 1', replace=True)
+        assert 'not a dynamically registered function' in str(ctx.exception)
 
 
 class TestDeleteFunctionIntegration(unittest.TestCase):

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -288,6 +288,7 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
         shared = SharedRegistry()
         base_reg = FunctionRegistry()
         base_reg.functions = {'base_fn': {'signature': {}, 'func': lambda: None}}
+        base_reg._base_function_names = {'base_fn'}
         shared.set_base_registry(base_reg)
         return shared
 
@@ -317,6 +318,17 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             shared.delete_function('ghost')
         assert 'not found' in str(ctx.exception)
+
+    def test_replace_base_via_shared_rejected(self):
+        shared = self._make_real_shared_registry()
+        sig = json.dumps({
+            'name': 'base_fn',
+            'args': [{'name': 'x', 'dtype': 'int', 'sql': 'INT'}],
+            'returns': [{'name': '', 'dtype': 'int', 'sql': 'INT'}],
+        })
+        with self.assertRaises(ValueError) as ctx:
+            shared.create_function(sig, 'return x + 1', True)
+        assert 'not a dynamically registered function' in str(ctx.exception)
 
     def test_register_delete_reregister(self):
         shared = self._make_real_shared_registry()

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -152,12 +152,12 @@ class TestControlSignalDispatch(unittest.TestCase):
         payload = json.dumps({'args': [], 'returns': [], 'body': 'x'}).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
-        assert 'function_name' in result.data
+        assert 'name' in result.data
 
     def test_register_missing_args(self):
         shared = self._make_shared_registry()
         payload = json.dumps({
-            'function_name': 'f', 'returns': [], 'body': 'x',
+            'name': 'f', 'returns': [], 'body': 'x',
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
@@ -166,7 +166,7 @@ class TestControlSignalDispatch(unittest.TestCase):
     def test_register_missing_returns(self):
         shared = self._make_shared_registry()
         payload = json.dumps({
-            'function_name': 'f', 'args': [], 'body': 'x',
+            'name': 'f', 'args': [], 'body': 'x',
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
@@ -175,7 +175,7 @@ class TestControlSignalDispatch(unittest.TestCase):
     def test_register_missing_body(self):
         shared = self._make_shared_registry()
         payload = json.dumps({
-            'function_name': 'f', 'args': [], 'returns': [],
+            'name': 'f', 'args': [], 'returns': [],
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
@@ -184,7 +184,7 @@ class TestControlSignalDispatch(unittest.TestCase):
     def test_register_args_not_list(self):
         shared = self._make_shared_registry()
         payload = json.dumps({
-            'function_name': 'f', 'args': 'notalist',
+            'name': 'f', 'args': 'notalist',
             'returns': [], 'body': 'x',
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
@@ -208,14 +208,14 @@ class TestControlSignalDispatch(unittest.TestCase):
         payload = json.dumps({}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
-        assert 'function_name' in result.data
+        assert 'name' in result.data
 
     def test_delete_nonexistent_function(self):
         shared = self._make_shared_registry()
         shared.delete_function.side_effect = ValueError(
             "Function 'no_such' not found",
         )
-        payload = json.dumps({'function_name': 'no_such'}).encode()
+        payload = json.dumps({'name': 'no_such'}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
         assert 'not found' in result.data
@@ -225,7 +225,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         shared.delete_function.side_effect = ValueError(
             "Cannot delete 'base_fn': not a dynamically registered function",
         )
-        payload = json.dumps({'function_name': 'base_fn'}).encode()
+        payload = json.dumps({'name': 'base_fn'}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
         assert 'not a dynamically registered function' in result.data
@@ -233,7 +233,7 @@ class TestControlSignalDispatch(unittest.TestCase):
     def test_delete_success(self):
         shared = self._make_shared_registry()
         shared.delete_function.return_value = None
-        payload = json.dumps({'function_name': 'my_func'}).encode()
+        payload = json.dumps({'name': 'my_func'}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is True
         data = json.loads(result.data)

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -268,6 +268,17 @@ class TestFunctionRegistryDeleteGuard(unittest.TestCase):
             reg.delete_function(json.dumps({'name': 'ghost'}))
         assert 'not found' in str(ctx.exception)
 
+    def test_replace_base_then_delete_allowed(self):
+        reg = self._make_registry_with_base()
+        sig = json.dumps({
+            'name': 'base_fn',
+            'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
+            'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
+        })
+        reg.create_function(sig, 'return x + 1', replace=True)
+        reg.delete_function(json.dumps({'name': 'base_fn'}))
+        assert 'base_fn' not in reg.functions
+
 
 class TestDeleteFunctionIntegration(unittest.TestCase):
     """Integration tests for @@delete using a real SharedRegistry."""

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -343,6 +343,27 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
         reg = shared.get_thread_local_registry()
         assert 'dyn_fn' in reg.functions
 
+    def test_deleted_function_does_not_reappear(self):
+        shared = self._make_real_shared_registry()
+        sig_a = json.dumps({
+            'name': 'fn_a',
+            'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
+            'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
+        })
+        shared.create_function(sig_a, 'return x + 1', False)
+        shared.delete_function('fn_a')
+
+        sig_b = json.dumps({
+            'name': 'fn_b',
+            'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
+            'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
+        })
+        shared.create_function(sig_b, 'return x + 2', False)
+
+        reg = shared.get_thread_local_registry()
+        assert 'fn_a' not in reg.functions
+        assert 'fn_b' in reg.functions
+
 
 class TestLazyImport(unittest.TestCase):
 

--- a/singlestoredb/tests/test_plugin_integration.py
+++ b/singlestoredb/tests/test_plugin_integration.py
@@ -339,7 +339,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         """@@register a function, then call it via call_function."""
         shared = self._make_shared()
         payload = json.dumps({
-            'function_name': 'double_it',
+            'name': 'double_it',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x * 2',
@@ -360,7 +360,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         """@@register with replace=true overwrites existing function."""
         shared = self._make_shared()
         payload1 = json.dumps({
-            'function_name': 'myfunc',
+            'name': 'myfunc',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x + 1',
@@ -369,7 +369,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         assert result.ok
 
         payload2 = json.dumps({
-            'function_name': 'myfunc',
+            'name': 'myfunc',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x + 100',
@@ -388,7 +388,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         """@@register without replace=true fails for existing function."""
         shared = self._make_shared()
         payload = json.dumps({
-            'function_name': 'dup_fn',
+            'name': 'dup_fn',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x',
@@ -404,14 +404,14 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         """@@delete removes a function so it's no longer callable."""
         shared = self._make_shared()
         payload = json.dumps({
-            'function_name': 'temp_fn',
+            'name': 'temp_fn',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x',
         }).encode()
         dispatch_control_signal('@@register', payload, shared)
 
-        del_payload = json.dumps({'function_name': 'temp_fn'}).encode()
+        del_payload = json.dumps({'name': 'temp_fn'}).encode()
         result = dispatch_control_signal('@@delete', del_payload, shared)
         assert result.ok
 
@@ -422,7 +422,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         """Delete a function and re-register it with new behavior."""
         shared = self._make_shared()
         sig = {
-            'function_name': 'morph',
+            'name': 'morph',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x + 1',
@@ -431,7 +431,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
 
         dispatch_control_signal(
             '@@delete',
-            json.dumps({'function_name': 'morph'}).encode(),
+            json.dumps({'name': 'morph'}).encode(),
             shared,
         )
 
@@ -450,7 +450,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         r_fd, w_fd = os.pipe()
         try:
             payload = json.dumps({
-                'function_name': 'piped_fn',
+                'name': 'piped_fn',
                 'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
                 'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
                 'body': 'return x',
@@ -474,7 +474,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
         """@@delete with pipe_write_fd sends message to parent."""
         shared = self._make_shared()
         sig = json.dumps({
-            'function_name': 'pipe_del',
+            'name': 'pipe_del',
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'body': 'return x',
@@ -483,7 +483,7 @@ class TestRegisterDeleteIntegration(unittest.TestCase):
 
         r_fd, w_fd = os.pipe()
         try:
-            del_payload = json.dumps({'function_name': 'pipe_del'}).encode()
+            del_payload = json.dumps({'name': 'pipe_del'}).encode()
             result = dispatch_control_signal(
                 '@@delete', del_payload, shared, pipe_write_fd=w_fd,
             )

--- a/wit/plugin.wit
+++ b/wit/plugin.wit
@@ -19,6 +19,12 @@ interface plugin {
     /// `code` is the function body (not a full `def` statement).
     /// `replace` controls whether an existing function of the same name is overwritten.
     create-function: func(signature: string, code: string, replace: bool) -> result<_, string>;
+
+    /// Delete a dynamically registered function by its signature.
+    /// `signature` is a JSON object matching the describe-functions element schema.
+    /// Currently uses only the `name` field; full signature matching reserved for
+    /// future overload support.
+    delete-function: func(signature: string) -> result<_, string>;
 }
 
 world plugin-server {


### PR DESCRIPTION
## Summary
- Adds a `delete-function` method to the WIT plugin interface and its Python implementation in `FunctionRegistry` and `Plugin`, enabling runtime removal of dynamically registered UDFs.
- Renames the control-plane JSON field from `function_name` to `name` to align with the `describe-functions` schema.

## Test plan
- [ ] Verify `delete-function` removes a previously registered function
- [ ] Verify deleting a non-existent function raises an appropriate error
- [ ] Verify register/delete round-trip via control plane endpoints
- [ ] Confirm existing `create-function` flow still works with `name` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for control clients still sending `function_name`; delete/reload touches shared registry and worker re-fork paths where stale or missing functions would affect live UDF calls.
> 
> **Overview**
> Adds **runtime deletion** of dynamically registered UDFs across the WASM WIT surface (`delete-function`), the Python `Plugin` adapter, `FunctionRegistry.delete_function`, and the existing `@@delete` control path (which now reads **`name`** instead of **`function_name`** in the JSON body, matching the describe-functions schema).
> 
> **Protection for built-in UDFs:** after discovery, the registry records `_base_function_names`; **delete** and **replace** via `create_function` are rejected for those names, while dynamic functions can still be removed (registry entry and `_dynamic` module attribute).
> 
> **SharedRegistry / process mode:** deleting drops matching code blocks and bumps generation; rebuilding a thread-local registry now resets the `_dynamic` module namespace before replaying blocks so deleted functions do not reappear. Tests cover guards, shared-registry delete/re-register, and the `name` field change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776f6aba314695a57abc697ff7130439ecc0de16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->