### PR TITLE
Adopt structured error codes for plugin UDF control signals

### DIFF
--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -3,7 +3,7 @@ Control signal dispatch for @@health, @@functions, @@register, @@delete.
 
 Matches the Rust wasm-udf-server's dispatch_control_signal behavior, including
 the structured-error-code shape from ADR 0001
-(``{"message": "...", "code": "SCREAMING_SNAKE"}`` on errors). The authoritative
+(``{"error": "...", "code": "SCREAMING_SNAKE"}`` on errors). The authoritative
 catalog of codes lives in ADR 0001 in the ``wasm-udf-server`` repo; the codes
 emitted from this module are:
 
@@ -53,7 +53,7 @@ class ControlResult:
     # JSON response. On success (``ok=True``) this is a handler-specific
     # document such as ``{"status":"ok"}`` or ``{"functions":[...]}``. On
     # failure (``ok=False``) this is the ADR 0001 error shape
-    # ``{"message":"...","code":"..."}``.
+    # ``{"error":"...","code":"..."}``.
     data: str
 
 
@@ -61,7 +61,7 @@ def _err(message: str, code: str) -> ControlResult:
     """Build an error ControlResult with the ADR 0001 JSON shape."""
     return ControlResult(
         ok=False,
-        data=json.dumps({'message': message, 'code': code}),
+        data=json.dumps({'error': message, 'code': code}),
     )
 
 

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -1,7 +1,11 @@
 """
 Control signal dispatch for @@health, @@functions, @@register, @@delete.
 
-Matches the Rust wasm-udf-server's dispatch_control_signal behavior.
+Matches the Rust wasm-udf-server's dispatch_control_signal behavior, including
+the structured-error-code shape from ADR 0001
+(``{"message": "...", "code": "SCREAMING_SNAKE"}`` on errors). The
+``REGISTER_DISABLED`` and ``DELETE_DISABLED`` codes from that catalog have no
+call site here because this server has no registration enable/disable flag.
 """
 from __future__ import annotations
 
@@ -22,7 +26,32 @@ logger = logging.getLogger('plugin.control')
 class ControlResult:
     """Result of a control signal dispatch."""
     ok: bool
-    data: str  # JSON response on success, error message on failure
+    data: str  # JSON response on success or failure (per ADR 0001)
+
+
+def _err(message: str, code: str) -> ControlResult:
+    """Build an error ControlResult with the ADR 0001 JSON shape."""
+    return ControlResult(
+        ok=False,
+        data=json.dumps({'message': message, 'code': code}),
+    )
+
+
+def _register_code_for(message: str) -> str:
+    """Pick a code for an exception raised by ``SharedRegistry.create_function``."""
+    if 'already exists' in message \
+            or 'not a dynamically registered function' in message:
+        return 'REGISTER_FUNC_EXISTS'
+    return 'REGISTER_INVALID_PAYLOAD'
+
+
+def _delete_code_for(message: str) -> str:
+    """Pick a code for an exception raised by ``SharedRegistry.delete_function``."""
+    if 'not a dynamically registered function' in message:
+        return 'DELETE_FUNC_NOT_REGISTERED'
+    if 'not found' in message:
+        return 'DELETE_FUNC_NOT_FOUND'
+    return 'DELETE_INVALID_PAYLOAD'
 
 
 def dispatch_control_signal(
@@ -46,12 +75,12 @@ def dispatch_control_signal(
                 request_data, shared_registry, pipe_write_fd,
             )
         else:
-            return ControlResult(
-                ok=False,
-                data=f'Unknown control signal: {signal_name}',
+            return _err(
+                f'Unknown control signal: {signal_name}',
+                'UNKNOWN_SIGNAL',
             )
     except Exception as e:
-        return ControlResult(ok=False, data=str(e))
+        return _err(str(e), 'UNKNOWN_SIGNAL')
 
 
 def _handle_health() -> ControlResult:
@@ -83,36 +112,37 @@ def _handle_register(
     own registry and re-fork all workers.
     """
     if not request_data:
-        return ControlResult(ok=False, data='Missing registration payload')
+        return _err('Missing registration payload', 'REGISTER_MISSING_PAYLOAD')
 
     try:
         body = json.loads(request_data)
     except json.JSONDecodeError as e:
-        return ControlResult(ok=False, data=f'Invalid JSON: {e}')
+        return _err(f'Invalid JSON: {e}', 'REGISTER_INVALID_PAYLOAD')
 
     function_name = body.get('name')
     if not function_name:
-        return ControlResult(
-            ok=False, data='Missing required field: name',
+        return _err(
+            'Missing required field: name', 'REGISTER_INVALID_PAYLOAD',
         )
 
     args = body.get('args')
     if not isinstance(args, list):
-        return ControlResult(
-            ok=False, data='Missing required field: args (must be an array)',
+        return _err(
+            'Missing required field: args (must be an array)',
+            'REGISTER_INVALID_PAYLOAD',
         )
 
     returns = body.get('returns')
     if not isinstance(returns, list):
-        return ControlResult(
-            ok=False,
-            data='Missing required field: returns (must be an array)',
+        return _err(
+            'Missing required field: returns (must be an array)',
+            'REGISTER_INVALID_PAYLOAD',
         )
 
     func_body = body.get('body')
     if not func_body:
-        return ControlResult(
-            ok=False, data='Missing required field: body',
+        return _err(
+            'Missing required field: body', 'REGISTER_INVALID_PAYLOAD',
         )
 
     replace = body.get('replace', False)
@@ -127,7 +157,8 @@ def _handle_register(
     try:
         shared_registry.create_function(signature, func_body, replace)
     except Exception as e:
-        return ControlResult(ok=False, data=str(e))
+        msg = str(e)
+        return _err(msg, _register_code_for(msg))
 
     # Notify main process so it can re-fork workers with updated state
     if pipe_write_fd is not None:
@@ -151,23 +182,24 @@ def _handle_delete(
 ) -> ControlResult:
     """Handle @@delete: delete a dynamically registered function."""
     if not request_data:
-        return ControlResult(ok=False, data='Missing deletion payload')
+        return _err('Missing deletion payload', 'DELETE_MISSING_PAYLOAD')
 
     try:
         body = json.loads(request_data)
     except json.JSONDecodeError as e:
-        return ControlResult(ok=False, data=f'Invalid JSON: {e}')
+        return _err(f'Invalid JSON: {e}', 'DELETE_INVALID_PAYLOAD')
 
     function_name = body.get('name')
     if not function_name:
-        return ControlResult(
-            ok=False, data='Missing required field: name',
+        return _err(
+            'Missing required field: name', 'DELETE_INVALID_PAYLOAD',
         )
 
     try:
         shared_registry.delete_function(function_name)
     except ValueError as e:
-        return ControlResult(ok=False, data=str(e))
+        msg = str(e)
+        return _err(msg, _delete_code_for(msg))
 
     # Notify main process so it can re-fork workers with updated state
     if pipe_write_fd is not None:

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -34,6 +34,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .registry import describe_functions_json
+from .registry import FunctionExistsError
+from .registry import FunctionNotDynamicError
+from .registry import FunctionNotFoundError
 
 if TYPE_CHECKING:
     from .server import SharedRegistry
@@ -58,25 +61,6 @@ def _err(message: str, code: str) -> ControlResult:
         ok=False,
         data=json.dumps({'message': message, 'code': code}),
     )
-
-
-def _register_code_for(message: str) -> str:
-    """Pick a code for an exception raised by ``SharedRegistry.create_function``."""
-    if 'Cannot replace' in message \
-            and 'not a dynamically registered function' in message:
-        return 'REGISTER_FUNC_NOT_DYNAMIC'
-    if 'already exists' in message:
-        return 'REGISTER_FUNC_EXISTS'
-    return 'REGISTER_INVALID_PAYLOAD'
-
-
-def _delete_code_for(message: str) -> str:
-    """Pick a code for an exception raised by ``SharedRegistry.delete_function``."""
-    if 'not a dynamically registered function' in message:
-        return 'DELETE_FUNC_NOT_REGISTERED'
-    if 'not found' in message:
-        return 'DELETE_FUNC_NOT_FOUND'
-    return 'DELETE_INVALID_PAYLOAD'
 
 
 def dispatch_control_signal(
@@ -181,9 +165,12 @@ def _handle_register(
 
     try:
         shared_registry.create_function(signature, func_body, replace)
+    except FunctionExistsError as e:
+        return _err(str(e), 'REGISTER_FUNC_EXISTS')
+    except FunctionNotDynamicError as e:
+        return _err(str(e), 'REGISTER_FUNC_NOT_DYNAMIC')
     except Exception as e:
-        msg = str(e)
-        return _err(msg, _register_code_for(msg))
+        return _err(str(e), 'REGISTER_INVALID_PAYLOAD')
 
     # Notify main process so it can re-fork workers with updated state
     if pipe_write_fd is not None:
@@ -222,9 +209,12 @@ def _handle_delete(
 
     try:
         shared_registry.delete_function(function_name)
+    except FunctionNotDynamicError as e:
+        return _err(str(e), 'DELETE_FUNC_NOT_REGISTERED')
+    except FunctionNotFoundError as e:
+        return _err(str(e), 'DELETE_FUNC_NOT_FOUND')
     except ValueError as e:
-        msg = str(e)
-        return _err(msg, _delete_code_for(msg))
+        return _err(str(e), 'DELETE_INVALID_PAYLOAD')
 
     # Notify main process so it can re-fork workers with updated state
     if pipe_write_fd is not None:

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -128,6 +128,12 @@ def _handle_register(
     except (json.JSONDecodeError, UnicodeDecodeError) as e:
         return _err(f'Invalid JSON: {e}', 'REGISTER_INVALID_PAYLOAD')
 
+    if not isinstance(body, dict):
+        return _err(
+            'Request body must be a JSON object',
+            'REGISTER_INVALID_PAYLOAD',
+        )
+
     function_name = body.get('name')
     if not function_name:
         return _err(
@@ -205,6 +211,12 @@ def _handle_delete(
         body = json.loads(request_data)
     except (json.JSONDecodeError, UnicodeDecodeError) as e:
         return _err(f'Invalid JSON: {e}', 'DELETE_INVALID_PAYLOAD')
+
+    if not isinstance(body, dict):
+        return _err(
+            'Request body must be a JSON object',
+            'DELETE_INVALID_PAYLOAD',
+        )
 
     function_name = body.get('name')
     if not function_name:

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -141,6 +141,10 @@ def _handle_register(
         return _err(
             'Missing required field: name', 'REGISTER_INVALID_PAYLOAD',
         )
+    if not isinstance(function_name, str):
+        return _err(
+            'Field "name" must be a string', 'REGISTER_INVALID_PAYLOAD',
+        )
 
     args = body.get('args')
     if not isinstance(args, list):
@@ -160,6 +164,10 @@ def _handle_register(
     if not func_body:
         return _err(
             'Missing required field: body', 'REGISTER_INVALID_PAYLOAD',
+        )
+    if not isinstance(func_body, str):
+        return _err(
+            'Field "body" must be a string', 'REGISTER_INVALID_PAYLOAD',
         )
 
     replace = body.get('replace', False)
@@ -224,6 +232,10 @@ def _handle_delete(
     if not function_name:
         return _err(
             'Missing required field: name', 'DELETE_INVALID_PAYLOAD',
+        )
+    if not isinstance(function_name, str):
+        return _err(
+            'Field "name" must be a string', 'DELETE_INVALID_PAYLOAD',
         )
 
     try:

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -39,8 +39,10 @@ def _err(message: str, code: str) -> ControlResult:
 
 def _register_code_for(message: str) -> str:
     """Pick a code for an exception raised by ``SharedRegistry.create_function``."""
-    if 'already exists' in message \
-            or 'not a dynamically registered function' in message:
+    if 'Cannot replace' in message \
+            and 'not a dynamically registered function' in message:
+        return 'REGISTER_FUNC_NOT_DYNAMIC'
+    if 'already exists' in message:
         return 'REGISTER_FUNC_EXISTS'
     return 'REGISTER_INVALID_PAYLOAD'
 

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -3,7 +3,9 @@ Control signal dispatch for @@health, @@functions, @@register, @@delete.
 
 Matches the Rust wasm-udf-server's dispatch_control_signal behavior, including
 the structured-error-code shape from ADR 0001
-(``{"message": "...", "code": "SCREAMING_SNAKE"}`` on errors). The
+(``{"message": "...", "code": "SCREAMING_SNAKE"}`` on errors). ``UNKNOWN_SIGNAL``
+is reserved for unrecognized ``@@``-prefixed signal names; ``INTERNAL_ERROR``
+is the cross-cutting fallback for unexpected handler exceptions. The
 ``REGISTER_DISABLED`` and ``DELETE_DISABLED`` codes from that catalog have no
 call site here because this server has no registration enable/disable flag.
 """
@@ -82,7 +84,7 @@ def dispatch_control_signal(
                 'UNKNOWN_SIGNAL',
             )
     except Exception as e:
-        return _err(str(e), 'UNKNOWN_SIGNAL')
+        return _err(str(e), 'INTERNAL_ERROR')
 
 
 def _handle_health() -> ControlResult:

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -169,7 +169,7 @@ def _handle_register(
         return _err(str(e), 'REGISTER_FUNC_EXISTS')
     except FunctionNotDynamicError as e:
         return _err(str(e), 'REGISTER_FUNC_NOT_DYNAMIC')
-    except Exception as e:
+    except (ValueError, SyntaxError, TypeError) as e:
         return _err(str(e), 'REGISTER_INVALID_PAYLOAD')
 
     # Notify main process so it can re-fork workers with updated state

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -3,11 +3,28 @@ Control signal dispatch for @@health, @@functions, @@register, @@delete.
 
 Matches the Rust wasm-udf-server's dispatch_control_signal behavior, including
 the structured-error-code shape from ADR 0001
-(``{"message": "...", "code": "SCREAMING_SNAKE"}`` on errors). ``UNKNOWN_SIGNAL``
-is reserved for unrecognized ``@@``-prefixed signal names; ``INTERNAL_ERROR``
-is the cross-cutting fallback for unexpected handler exceptions. The
-``REGISTER_DISABLED`` and ``DELETE_DISABLED`` codes from that catalog have no
-call site here because this server has no registration enable/disable flag.
+(``{"message": "...", "code": "SCREAMING_SNAKE"}`` on errors). The authoritative
+catalog of codes lives in ADR 0001 in the ``wasm-udf-server`` repo; the codes
+emitted from this module are:
+
+- ``UNKNOWN_SIGNAL`` — unrecognized ``@@``-prefixed signal name.
+- ``INTERNAL_ERROR`` — cross-cutting fallback for unexpected handler exceptions.
+- ``REGISTER_MISSING_PAYLOAD`` — ``@@register`` called with an empty body.
+- ``REGISTER_INVALID_PAYLOAD`` — ``@@register`` body failed JSON parsing or
+  field validation.
+- ``REGISTER_FUNC_EXISTS`` — function with the same name is already registered
+  and ``replace`` was not requested.
+- ``REGISTER_FUNC_NOT_DYNAMIC`` — ``replace`` requested for a function that was
+  not dynamically registered (e.g., a built-in).
+- ``DELETE_MISSING_PAYLOAD`` — ``@@delete`` called with an empty body.
+- ``DELETE_INVALID_PAYLOAD`` — ``@@delete`` body failed JSON parsing or field
+  validation.
+- ``DELETE_FUNC_NOT_REGISTERED`` — target function exists but was not
+  dynamically registered, so it cannot be deleted.
+- ``DELETE_FUNC_NOT_FOUND`` — target function does not exist.
+
+The ``REGISTER_DISABLED`` and ``DELETE_DISABLED`` codes from that catalog have
+no call site here because this server has no registration enable/disable flag.
 """
 from __future__ import annotations
 
@@ -28,7 +45,11 @@ logger = logging.getLogger('plugin.control')
 class ControlResult:
     """Result of a control signal dispatch."""
     ok: bool
-    data: str  # JSON response on success or failure (per ADR 0001)
+    # JSON response. On success (``ok=True``) this is a handler-specific
+    # document such as ``{"status":"ok"}`` or ``{"functions":[...]}``. On
+    # failure (``ok=False``) this is the ADR 0001 error shape
+    # ``{"message":"...","code":"..."}``.
+    data: str
 
 
 def _err(message: str, code: str) -> ControlResult:

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -125,7 +125,7 @@ def _handle_register(
 
     try:
         body = json.loads(request_data)
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
         return _err(f'Invalid JSON: {e}', 'REGISTER_INVALID_PAYLOAD')
 
     function_name = body.get('name')
@@ -155,6 +155,11 @@ def _handle_register(
         )
 
     replace = body.get('replace', False)
+    if not isinstance(replace, bool):
+        return _err(
+            'Field "replace" must be a boolean',
+            'REGISTER_INVALID_PAYLOAD',
+        )
 
     # Build signature JSON matching describe-functions schema
     signature = json.dumps({
@@ -198,7 +203,7 @@ def _handle_delete(
 
     try:
         body = json.loads(request_data)
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
         return _err(f'Invalid JSON: {e}', 'DELETE_INVALID_PAYLOAD')
 
     function_name = body.get('name')

--- a/singlestoredb/functions/ext/plugin/control.py
+++ b/singlestoredb/functions/ext/plugin/control.py
@@ -14,8 +14,10 @@ emitted from this module are:
   field validation.
 - ``REGISTER_FUNC_EXISTS`` — function with the same name is already registered
   and ``replace`` was not requested.
-- ``REGISTER_FUNC_NOT_DYNAMIC`` — ``replace`` requested for a function that was
-  not dynamically registered (e.g., a built-in).
+- ``REGISTER_FUNC_NOT_DYNAMIC`` — registration targets a name reserved by a
+  base/built-in function. This covers both replacing a base function (when
+  ``replace`` is requested) and registering a new function whose name collides
+  with a base function (even when ``replace`` is not requested).
 - ``DELETE_MISSING_PAYLOAD`` — ``@@delete`` called with an empty body.
 - ``DELETE_INVALID_PAYLOAD`` — ``@@delete`` body failed JSON parsing or field
   validation.
@@ -230,8 +232,8 @@ def _handle_delete(
         return _err(str(e), 'DELETE_FUNC_NOT_REGISTERED')
     except FunctionNotFoundError as e:
         return _err(str(e), 'DELETE_FUNC_NOT_FOUND')
-    except ValueError as e:
-        return _err(str(e), 'DELETE_INVALID_PAYLOAD')
+    except Exception as e:
+        return _err(str(e), 'INTERNAL_ERROR')
 
     # Notify main process so it can re-fork workers with updated state
     if pipe_write_fd is not None:

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -141,6 +141,18 @@ _dtype_to_python: Dict[str, str] = {
 logger = logging.getLogger('udf_handler')
 
 
+class FunctionExistsError(ValueError):
+    """Raised when a function name is already registered and replace=False."""
+
+
+class FunctionNotDynamicError(ValueError):
+    """Raised when replacing/deleting a function that was not dynamically registered."""
+
+
+class FunctionNotFoundError(ValueError):
+    """Raised when the target function does not exist (delete only)."""
+
+
 class FunctionRegistry:
     """Registry of discovered UDF functions."""
 
@@ -387,13 +399,13 @@ class FunctionRegistry:
             )
 
         if not replace and func_name in self.functions:
-            raise ValueError(
+            raise FunctionExistsError(
                 f'Function "{func_name}" already exists '
                 f'(use replace=true to overwrite)',
             )
 
         if func_name in self._base_function_names:
-            raise ValueError(
+            raise FunctionNotDynamicError(
                 f"Cannot replace '{func_name}': "
                 f'not a dynamically registered function',
             )
@@ -447,9 +459,9 @@ class FunctionRegistry:
                 'signature JSON must contain a "name" field',
             )
         if name not in self.functions:
-            raise ValueError(f"Function '{name}' not found")
+            raise FunctionNotFoundError(f"Function '{name}' not found")
         if name in self._base_function_names:
-            raise ValueError(
+            raise FunctionNotDynamicError(
                 f"Cannot delete '{name}': not a dynamically registered function",
             )
         del self.functions[name]

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -399,16 +399,16 @@ class FunctionRegistry:
                 'signature JSON must contain a "name" field',
             )
 
+        if func_name in self._base_function_names:
+            raise FunctionNotDynamicError(
+                f"Cannot register '{func_name}': "
+                f'name is reserved by a built-in (non-dynamic) function',
+            )
+
         if not replace and func_name in self.functions:
             raise FunctionExistsError(
                 f'Function "{func_name}" already exists '
                 f'(use replace=true to overwrite)',
-            )
-
-        if replace and func_name in self._base_function_names:
-            raise FunctionNotDynamicError(
-                f"Cannot replace '{func_name}': "
-                f'not a dynamically registered function',
             )
 
         if replace and func_name in self.functions:

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -398,16 +398,16 @@ class FunctionRegistry:
                 'signature JSON must contain a "name" field',
             )
 
-        if not replace and func_name in self.functions:
-            raise FunctionExistsError(
-                f'Function "{func_name}" already exists '
-                f'(use replace=true to overwrite)',
-            )
-
         if func_name in self._base_function_names:
             raise FunctionNotDynamicError(
                 f"Cannot replace '{func_name}': "
                 f'not a dynamically registered function',
+            )
+
+        if not replace and func_name in self.functions:
+            raise FunctionExistsError(
+                f'Function "{func_name}" already exists '
+                f'(use replace=true to overwrite)',
             )
 
         if replace and func_name in self.functions:

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -146,7 +146,8 @@ class FunctionExistsError(ValueError):
 
 
 class FunctionNotDynamicError(ValueError):
-    """Raised when replacing/deleting a function that was not dynamically registered."""
+    """Raised when an operation targets a function that exists but was not
+    dynamically registered (e.g., replacing or deleting a built-in)."""
 
 
 class FunctionNotFoundError(ValueError):
@@ -398,16 +399,16 @@ class FunctionRegistry:
                 'signature JSON must contain a "name" field',
             )
 
-        if func_name in self._base_function_names:
-            raise FunctionNotDynamicError(
-                f"Cannot replace '{func_name}': "
-                f'not a dynamically registered function',
-            )
-
         if not replace and func_name in self.functions:
             raise FunctionExistsError(
                 f'Function "{func_name}" already exists '
                 f'(use replace=true to overwrite)',
+            )
+
+        if replace and func_name in self._base_function_names:
+            raise FunctionNotDynamicError(
+                f"Cannot replace '{func_name}': "
+                f'not a dynamically registered function',
             )
 
         if replace and func_name in self.functions:

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -450,7 +450,11 @@ class FunctionRegistry:
                 element schema (must contain a 'name' field). Currently
                 only the name is used for matching.
 
-        Raises ValueError if the function does not exist.
+        Raises:
+            ValueError: if the signature JSON is missing a "name" field.
+            FunctionNotFoundError: if no function with that name is registered.
+            FunctionNotDynamicError: if the function exists but was not
+                dynamically registered (e.g., a built-in).
         """
         sig = json.loads(signature_json)
         name = sig.get('name')

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -401,6 +401,27 @@ class FunctionRegistry:
                 'signature JSON must contain a "name" field',
             )
 
+        for kind in ('args', 'returns'):
+            items = sig.get(kind, [])
+            if not isinstance(items, list):
+                raise ValueError(f'"{kind}" must be a list')
+            for i, item in enumerate(items):
+                if not isinstance(item, dict):
+                    raise ValueError(
+                        f'"{kind}[{i}]" must be a JSON object',
+                    )
+                dtype = item.get('dtype')
+                if not isinstance(dtype, str):
+                    raise ValueError(
+                        f'"{kind}[{i}].dtype" must be a string',
+                    )
+                if kind == 'args':
+                    name = item.get('name')
+                    if not isinstance(name, str) or not name:
+                        raise ValueError(
+                            f'"{kind}[{i}].name" must be a non-empty string',
+                        )
+
         if func_name in self._base_function_names:
             raise FunctionNotDynamicError(
                 f"Cannot register '{func_name}': "

--- a/singlestoredb/functions/ext/plugin/registry.py
+++ b/singlestoredb/functions/ext/plugin/registry.py
@@ -146,8 +146,10 @@ class FunctionExistsError(ValueError):
 
 
 class FunctionNotDynamicError(ValueError):
-    """Raised when an operation targets a function that exists but was not
-    dynamically registered (e.g., replacing or deleting a built-in)."""
+    """Raised when an operation (register, replace, or delete) targets a
+    function name reserved by a base/built-in (non-dynamic) function. This
+    covers registering a new function whose name collides with a base
+    function as well as attempts to replace or delete a base function."""
 
 
 class FunctionNotFoundError(ValueError):

--- a/singlestoredb/functions/ext/plugin/server.py
+++ b/singlestoredb/functions/ext/plugin/server.py
@@ -28,6 +28,8 @@ from typing import Tuple
 
 from .connection import _write_all_fd
 from .connection import handle_connection
+from .registry import FunctionNotDynamicError
+from .registry import FunctionNotFoundError
 from .registry import FunctionRegistry
 
 logger = logging.getLogger('plugin.server')
@@ -131,8 +133,9 @@ class SharedRegistry:
     def delete_function(self, function_name: str) -> None:
         """Delete a dynamically registered function by name.
 
-        Raises ValueError if the function was not dynamically registered
-        or does not exist at all.
+        Raises FunctionNotDynamicError if the function exists as a base
+        (non-dynamic) function, FunctionNotFoundError if it does not
+        exist at all.
         """
         with self._lock:
             # Find matching code blocks by parsing signature_json
@@ -148,11 +151,11 @@ class SharedRegistry:
                     self._base_registry is not None
                     and function_name in self._base_registry.functions
                 ):
-                    raise ValueError(
+                    raise FunctionNotDynamicError(
                         f"Cannot delete '{function_name}': "
                         f'not a dynamically registered function',
                     )
-                raise ValueError(
+                raise FunctionNotFoundError(
                     f"Function '{function_name}' not found",
                 )
 

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -380,15 +380,45 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
 
     def test_delete_base_function_errors(self):
         shared = self._make_real_shared_registry()
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(FunctionNotDynamicError) as ctx:
             shared.delete_function('base_fn')
         assert 'not a dynamically registered function' in str(ctx.exception)
 
     def test_delete_nonexistent_errors(self):
         shared = self._make_real_shared_registry()
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(FunctionNotFoundError) as ctx:
             shared.delete_function('ghost')
         assert 'not found' in str(ctx.exception)
+
+    def test_dispatch_delete_nonexistent_returns_func_not_found(self):
+        """End-to-end @@delete on a real registry returns the typed code.
+
+        Regression test: prior to the typed-exception fix in
+        SharedRegistry.delete_function, this scenario fell through to
+        the generic ValueError branch and returned DELETE_INVALID_PAYLOAD.
+        """
+        shared = self._make_real_shared_registry()
+        payload = json.dumps({'name': 'ghost'}).encode()
+        result = dispatch_control_signal('@@delete', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_FUNC_NOT_FOUND'
+        assert 'not found' in body['message']
+
+    def test_dispatch_delete_base_function_returns_not_registered(self):
+        """End-to-end @@delete on a base function returns the typed code.
+
+        Regression test: prior to the typed-exception fix in
+        SharedRegistry.delete_function, this scenario fell through to
+        the generic ValueError branch and returned DELETE_INVALID_PAYLOAD.
+        """
+        shared = self._make_real_shared_registry()
+        payload = json.dumps({'name': 'base_fn'}).encode()
+        result = dispatch_control_signal('@@delete', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_FUNC_NOT_REGISTERED'
+        assert 'not a dynamically registered function' in body['message']
 
     def test_replace_base_via_shared_rejected(self):
         shared = self._make_real_shared_registry()

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -360,16 +360,16 @@ class TestFunctionRegistryDeleteGuard(unittest.TestCase):
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
         })
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(FunctionNotDynamicError) as ctx:
             reg.create_function(sig, 'return x + 1', replace=True)
-        assert 'not a dynamically registered function' in str(ctx.exception)
+        assert 'reserved by a built-in' in str(ctx.exception)
 
-    def test_register_base_name_without_replace_returns_exists(self):
-        """Regression: a first-time @@register colliding with a base
-        function name must raise FunctionExistsError (so the dispatcher
-        emits REGISTER_FUNC_EXISTS), not FunctionNotDynamicError. The
-        NOT_DYNAMIC code is reserved for replace=True against a
-        non-dynamic function, per ADR-0001.
+    def test_register_base_name_without_replace_returns_not_dynamic(self):
+        """A @@register colliding with a base (non-dynamic) function name
+        must raise FunctionNotDynamicError regardless of ``replace``, so
+        the dispatcher emits REGISTER_FUNC_NOT_DYNAMIC. Suggesting
+        ``replace=true`` would be misleading since base names cannot be
+        overwritten by either path.
         """
         reg = self._make_registry_with_base()
         sig = json.dumps({
@@ -377,9 +377,9 @@ class TestFunctionRegistryDeleteGuard(unittest.TestCase):
             'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
             'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
         })
-        with self.assertRaises(FunctionExistsError) as ctx:
+        with self.assertRaises(FunctionNotDynamicError) as ctx:
             reg.create_function(sig, 'return x + 1', replace=False)
-        assert 'already exists' in str(ctx.exception)
+        assert 'reserved by a built-in' in str(ctx.exception)
 
 
 class TestDeleteFunctionIntegration(unittest.TestCase):
@@ -458,9 +458,9 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
             'args': [{'name': 'x', 'dtype': 'int', 'sql': 'INT'}],
             'returns': [{'name': '', 'dtype': 'int', 'sql': 'INT'}],
         })
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(FunctionNotDynamicError) as ctx:
             shared.create_function(sig, 'return x + 1', True)
-        assert 'not a dynamically registered function' in str(ctx.exception)
+        assert 'reserved by a built-in' in str(ctx.exception)
 
     def test_register_delete_reregister(self):
         shared = self._make_real_shared_registry()

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -133,26 +133,34 @@ class TestControlSignalDispatch(unittest.TestCase):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@unknown', b'', shared)
         assert result.ok is False
-        assert 'Unknown control signal' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'UNKNOWN_SIGNAL'
+        assert 'Unknown control signal' in body['message']
 
     def test_register_missing_payload(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@register', b'', shared)
         assert result.ok is False
-        assert 'Missing registration payload' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_MISSING_PAYLOAD'
+        assert 'Missing registration payload' in body['message']
 
     def test_register_invalid_json(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@register', b'not json', shared)
         assert result.ok is False
-        assert 'Invalid JSON' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'Invalid JSON' in body['message']
 
     def test_register_missing_function_name(self):
         shared = self._make_shared_registry()
         payload = json.dumps({'args': [], 'returns': [], 'body': 'x'}).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
-        assert 'name' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'name' in body['message']
 
     def test_register_missing_args(self):
         shared = self._make_shared_registry()
@@ -161,7 +169,9 @@ class TestControlSignalDispatch(unittest.TestCase):
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
-        assert 'args' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'args' in body['message']
 
     def test_register_missing_returns(self):
         shared = self._make_shared_registry()
@@ -170,7 +180,9 @@ class TestControlSignalDispatch(unittest.TestCase):
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
-        assert 'returns' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'returns' in body['message']
 
     def test_register_missing_body(self):
         shared = self._make_shared_registry()
@@ -179,7 +191,9 @@ class TestControlSignalDispatch(unittest.TestCase):
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
-        assert 'body' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'body' in body['message']
 
     def test_register_args_not_list(self):
         shared = self._make_shared_registry()
@@ -189,26 +203,48 @@ class TestControlSignalDispatch(unittest.TestCase):
         }).encode()
         result = dispatch_control_signal('@@register', payload, shared)
         assert result.ok is False
-        assert 'args' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'args' in body['message']
+
+    def test_register_func_exists(self):
+        shared = self._make_shared_registry()
+        shared.create_function.side_effect = ValueError(
+            'Function "f" already exists (use replace=true to overwrite)',
+        )
+        payload = json.dumps({
+            'name': 'f', 'args': [], 'returns': [], 'body': 'x',
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_FUNC_EXISTS'
+        assert 'already exists' in body['message']
 
     def test_delete_missing_payload(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@delete', b'', shared)
         assert result.ok is False
-        assert 'Missing deletion payload' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_MISSING_PAYLOAD'
+        assert 'Missing deletion payload' in body['message']
 
     def test_delete_invalid_json(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@delete', b'not json', shared)
         assert result.ok is False
-        assert 'Invalid JSON' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_INVALID_PAYLOAD'
+        assert 'Invalid JSON' in body['message']
 
     def test_delete_missing_function_name(self):
         shared = self._make_shared_registry()
         payload = json.dumps({}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
-        assert 'name' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_INVALID_PAYLOAD'
+        assert 'name' in body['message']
 
     def test_delete_nonexistent_function(self):
         shared = self._make_shared_registry()
@@ -218,7 +254,9 @@ class TestControlSignalDispatch(unittest.TestCase):
         payload = json.dumps({'name': 'no_such'}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
-        assert 'not found' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_FUNC_NOT_FOUND'
+        assert 'not found' in body['message']
 
     def test_delete_base_function(self):
         shared = self._make_shared_registry()
@@ -228,7 +266,9 @@ class TestControlSignalDispatch(unittest.TestCase):
         payload = json.dumps({'name': 'base_fn'}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
-        assert 'not a dynamically registered function' in result.data
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_FUNC_NOT_REGISTERED'
+        assert 'not a dynamically registered function' in body['message']
 
     def test_delete_success(self):
         shared = self._make_shared_registry()

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -364,6 +364,23 @@ class TestFunctionRegistryDeleteGuard(unittest.TestCase):
             reg.create_function(sig, 'return x + 1', replace=True)
         assert 'not a dynamically registered function' in str(ctx.exception)
 
+    def test_register_base_name_without_replace_returns_exists(self):
+        """Regression: a first-time @@register colliding with a base
+        function name must raise FunctionExistsError (so the dispatcher
+        emits REGISTER_FUNC_EXISTS), not FunctionNotDynamicError. The
+        NOT_DYNAMIC code is reserved for replace=True against a
+        non-dynamic function, per ADR-0001.
+        """
+        reg = self._make_registry_with_base()
+        sig = json.dumps({
+            'name': 'base_fn',
+            'args': [{'name': 'x', 'dtype': 'int64', 'sql': 'BIGINT'}],
+            'returns': [{'name': '', 'dtype': 'int64', 'sql': 'BIGINT'}],
+        })
+        with self.assertRaises(FunctionExistsError) as ctx:
+            reg.create_function(sig, 'return x + 1', replace=False)
+        assert 'already exists' in str(ctx.exception)
+
 
 class TestDeleteFunctionIntegration(unittest.TestCase):
     """Integration tests for @@delete using a real SharedRegistry."""

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -223,6 +223,62 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
         assert 'args' in body['message']
 
+    def test_register_name_not_string(self):
+        shared = self._make_shared_registry()
+        payload = json.dumps({
+            'name': 123, 'args': [], 'returns': [], 'body': 'return 1',
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'name' in body['message']
+
+    def test_register_body_not_string(self):
+        shared = self._make_shared_registry()
+        payload = json.dumps({
+            'name': 'f', 'args': [], 'returns': [], 'body': 12345,
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'body' in body['message']
+
+    def test_register_arg_missing_dtype(self):
+        """An arg dict missing 'dtype' is a client-shape error and must
+        surface as REGISTER_INVALID_PAYLOAD, not INTERNAL_ERROR."""
+        shared = self._make_shared_registry()
+        shared.create_function.side_effect = ValueError(
+            '"args[0].dtype" must be a string',
+        )
+        payload = json.dumps({
+            'name': 'f', 'args': [{'name': 'x'}], 'returns': [],
+            'body': 'return 1',
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'dtype' in body['message']
+
+    def test_register_return_missing_dtype(self):
+        """A returns dict missing 'dtype' is a client-shape error and must
+        surface as REGISTER_INVALID_PAYLOAD, not INTERNAL_ERROR."""
+        shared = self._make_shared_registry()
+        shared.create_function.side_effect = ValueError(
+            '"returns[0].dtype" must be a string',
+        )
+        payload = json.dumps({
+            'name': 'f', 'args': [], 'returns': [{'name': ''}],
+            'body': 'return 1',
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
+        assert 'dtype' in body['message']
+
     def test_register_func_exists(self):
         shared = self._make_shared_registry()
         shared.create_function.side_effect = FunctionExistsError(
@@ -285,6 +341,17 @@ class TestControlSignalDispatch(unittest.TestCase):
     def test_delete_missing_function_name(self):
         shared = self._make_shared_registry()
         payload = json.dumps({}).encode()
+        result = dispatch_control_signal('@@delete', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'DELETE_INVALID_PAYLOAD'
+        assert 'name' in body['message']
+
+    def test_delete_name_not_string(self):
+        """A non-string name (e.g. dict) must surface as
+        DELETE_INVALID_PAYLOAD, not INTERNAL_ERROR."""
+        shared = self._make_shared_registry()
+        payload = json.dumps({'name': {'x': 1}}).encode()
         result = dispatch_control_signal('@@delete', payload, shared)
         assert result.ok is False
         body = json.loads(result.data)
@@ -363,6 +430,33 @@ class TestFunctionRegistryDeleteGuard(unittest.TestCase):
         with self.assertRaises(FunctionNotDynamicError) as ctx:
             reg.create_function(sig, 'return x + 1', replace=True)
         assert 'reserved by a built-in' in str(ctx.exception)
+
+    def test_create_function_arg_missing_dtype_raises_value_error(self):
+        reg = FunctionRegistry()
+        sig = json.dumps({
+            'name': 'f', 'args': [{'name': 'x'}], 'returns': [],
+        })
+        with self.assertRaises(ValueError) as ctx:
+            reg.create_function(sig, 'return 1', replace=False)
+        assert 'dtype' in str(ctx.exception)
+
+    def test_create_function_return_missing_dtype_raises_value_error(self):
+        reg = FunctionRegistry()
+        sig = json.dumps({
+            'name': 'f', 'args': [], 'returns': [{'name': ''}],
+        })
+        with self.assertRaises(ValueError) as ctx:
+            reg.create_function(sig, 'return 1', replace=False)
+        assert 'dtype' in str(ctx.exception)
+
+    def test_create_function_arg_item_not_dict_raises_value_error(self):
+        reg = FunctionRegistry()
+        sig = json.dumps({
+            'name': 'f', 'args': [1, 2], 'returns': [],
+        })
+        with self.assertRaises(ValueError) as ctx:
+            reg.create_function(sig, 'return 1', replace=False)
+        assert 'args[0]' in str(ctx.exception)
 
     def test_register_base_name_without_replace_returns_not_dynamic(self):
         """A @@register colliding with a base (non-dynamic) function name

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -138,7 +138,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'UNKNOWN_SIGNAL'
-        assert 'Unknown control signal' in body['message']
+        assert 'Unknown control signal' in body['error']
 
     def test_internal_error_on_handler_failure(self):
         shared = self._make_shared_registry()
@@ -151,7 +151,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'INTERNAL_ERROR'
-        assert 'boom' in body['message']
+        assert 'boom' in body['error']
 
     def test_register_missing_payload(self):
         shared = self._make_shared_registry()
@@ -159,7 +159,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_MISSING_PAYLOAD'
-        assert 'Missing registration payload' in body['message']
+        assert 'Missing registration payload' in body['error']
 
     def test_register_invalid_json(self):
         shared = self._make_shared_registry()
@@ -167,7 +167,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'Invalid JSON' in body['message']
+        assert 'Invalid JSON' in body['error']
 
     def test_register_missing_function_name(self):
         shared = self._make_shared_registry()
@@ -176,7 +176,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'name' in body['message']
+        assert 'name' in body['error']
 
     def test_register_missing_args(self):
         shared = self._make_shared_registry()
@@ -187,7 +187,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'args' in body['message']
+        assert 'args' in body['error']
 
     def test_register_missing_returns(self):
         shared = self._make_shared_registry()
@@ -198,7 +198,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'returns' in body['message']
+        assert 'returns' in body['error']
 
     def test_register_missing_body(self):
         shared = self._make_shared_registry()
@@ -209,7 +209,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'body' in body['message']
+        assert 'body' in body['error']
 
     def test_register_args_not_list(self):
         shared = self._make_shared_registry()
@@ -221,7 +221,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'args' in body['message']
+        assert 'args' in body['error']
 
     def test_register_name_not_string(self):
         shared = self._make_shared_registry()
@@ -232,7 +232,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'name' in body['message']
+        assert 'name' in body['error']
 
     def test_register_body_not_string(self):
         shared = self._make_shared_registry()
@@ -243,7 +243,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'body' in body['message']
+        assert 'body' in body['error']
 
     def test_register_arg_missing_dtype(self):
         """An arg dict missing 'dtype' is a client-shape error and must
@@ -260,7 +260,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'dtype' in body['message']
+        assert 'dtype' in body['error']
 
     def test_register_return_missing_dtype(self):
         """A returns dict missing 'dtype' is a client-shape error and must
@@ -277,7 +277,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_INVALID_PAYLOAD'
-        assert 'dtype' in body['message']
+        assert 'dtype' in body['error']
 
     def test_register_func_exists(self):
         shared = self._make_shared_registry()
@@ -291,7 +291,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_FUNC_EXISTS'
-        assert 'already exists' in body['message']
+        assert 'already exists' in body['error']
 
     def test_register_replace_base_function(self):
         shared = self._make_shared_registry()
@@ -306,7 +306,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'REGISTER_FUNC_NOT_DYNAMIC'
-        assert 'not a dynamically registered function' in body['message']
+        assert 'not a dynamically registered function' in body['error']
 
     def test_register_unexpected_internal_error(self):
         shared = self._make_shared_registry()
@@ -320,7 +320,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'INTERNAL_ERROR'
-        assert 'simulated infrastructure failure' in body['message']
+        assert 'simulated infrastructure failure' in body['error']
 
     def test_delete_missing_payload(self):
         shared = self._make_shared_registry()
@@ -328,7 +328,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_MISSING_PAYLOAD'
-        assert 'Missing deletion payload' in body['message']
+        assert 'Missing deletion payload' in body['error']
 
     def test_delete_invalid_json(self):
         shared = self._make_shared_registry()
@@ -336,7 +336,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_INVALID_PAYLOAD'
-        assert 'Invalid JSON' in body['message']
+        assert 'Invalid JSON' in body['error']
 
     def test_delete_missing_function_name(self):
         shared = self._make_shared_registry()
@@ -345,7 +345,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_INVALID_PAYLOAD'
-        assert 'name' in body['message']
+        assert 'name' in body['error']
 
     def test_delete_name_not_string(self):
         """A non-string name (e.g. dict) must surface as
@@ -356,7 +356,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_INVALID_PAYLOAD'
-        assert 'name' in body['message']
+        assert 'name' in body['error']
 
     def test_delete_nonexistent_function(self):
         shared = self._make_shared_registry()
@@ -368,7 +368,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_FUNC_NOT_FOUND'
-        assert 'not found' in body['message']
+        assert 'not found' in body['error']
 
     def test_delete_base_function(self):
         shared = self._make_shared_registry()
@@ -380,7 +380,7 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_FUNC_NOT_REGISTERED'
-        assert 'not a dynamically registered function' in body['message']
+        assert 'not a dynamically registered function' in body['error']
 
     def test_delete_success(self):
         shared = self._make_shared_registry()
@@ -528,7 +528,7 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_FUNC_NOT_FOUND'
-        assert 'not found' in body['message']
+        assert 'not found' in body['error']
 
     def test_dispatch_delete_base_function_returns_not_registered(self):
         """End-to-end @@delete on a base function returns the typed code.
@@ -543,7 +543,7 @@ class TestDeleteFunctionIntegration(unittest.TestCase):
         assert result.ok is False
         body = json.loads(result.data)
         assert body['code'] == 'DELETE_FUNC_NOT_REGISTERED'
-        assert 'not a dynamically registered function' in body['message']
+        assert 'not a dynamically registered function' in body['error']
 
     def test_replace_base_via_shared_rejected(self):
         shared = self._make_real_shared_registry()

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -137,6 +137,19 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert body['code'] == 'UNKNOWN_SIGNAL'
         assert 'Unknown control signal' in body['message']
 
+    def test_internal_error_on_handler_failure(self):
+        shared = self._make_shared_registry()
+        with patch(
+            'singlestoredb.functions.ext.plugin.control'
+            '.describe_functions_json',
+            side_effect=RuntimeError('boom'),
+        ):
+            result = dispatch_control_signal('@@functions', b'', shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'INTERNAL_ERROR'
+        assert 'boom' in body['message']
+
     def test_register_missing_payload(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@register', b'', shared)

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -221,6 +221,21 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert body['code'] == 'REGISTER_FUNC_EXISTS'
         assert 'already exists' in body['message']
 
+    def test_register_replace_base_function(self):
+        shared = self._make_shared_registry()
+        shared.create_function.side_effect = ValueError(
+            "Cannot replace 'base_fn': not a dynamically registered function",
+        )
+        payload = json.dumps({
+            'name': 'base_fn', 'args': [], 'returns': [],
+            'body': 'x', 'replace': True,
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'REGISTER_FUNC_NOT_DYNAMIC'
+        assert 'not a dynamically registered function' in body['message']
+
     def test_delete_missing_payload(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@delete', b'', shared)

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -18,6 +18,9 @@ from singlestoredb.functions.ext.plugin.connection import _MAX_FUNCTION_NAME_LEN
 from singlestoredb.functions.ext.plugin.connection import _recv_exact_py
 from singlestoredb.functions.ext.plugin.connection import PROTOCOL_VERSION
 from singlestoredb.functions.ext.plugin.control import dispatch_control_signal
+from singlestoredb.functions.ext.plugin.registry import FunctionExistsError
+from singlestoredb.functions.ext.plugin.registry import FunctionNotDynamicError
+from singlestoredb.functions.ext.plugin.registry import FunctionNotFoundError
 from singlestoredb.functions.ext.plugin.registry import FunctionRegistry
 from singlestoredb.utils._lazy_import import get_numpy
 from singlestoredb.utils._lazy_import import get_pandas
@@ -222,7 +225,7 @@ class TestControlSignalDispatch(unittest.TestCase):
 
     def test_register_func_exists(self):
         shared = self._make_shared_registry()
-        shared.create_function.side_effect = ValueError(
+        shared.create_function.side_effect = FunctionExistsError(
             'Function "f" already exists (use replace=true to overwrite)',
         )
         payload = json.dumps({
@@ -236,7 +239,7 @@ class TestControlSignalDispatch(unittest.TestCase):
 
     def test_register_replace_base_function(self):
         shared = self._make_shared_registry()
-        shared.create_function.side_effect = ValueError(
+        shared.create_function.side_effect = FunctionNotDynamicError(
             "Cannot replace 'base_fn': not a dynamically registered function",
         )
         payload = json.dumps({
@@ -276,7 +279,7 @@ class TestControlSignalDispatch(unittest.TestCase):
 
     def test_delete_nonexistent_function(self):
         shared = self._make_shared_registry()
-        shared.delete_function.side_effect = ValueError(
+        shared.delete_function.side_effect = FunctionNotFoundError(
             "Function 'no_such' not found",
         )
         payload = json.dumps({'name': 'no_such'}).encode()
@@ -288,7 +291,7 @@ class TestControlSignalDispatch(unittest.TestCase):
 
     def test_delete_base_function(self):
         shared = self._make_shared_registry()
-        shared.delete_function.side_effect = ValueError(
+        shared.delete_function.side_effect = FunctionNotDynamicError(
             "Cannot delete 'base_fn': not a dynamically registered function",
         )
         payload = json.dumps({'name': 'base_fn'}).encode()

--- a/singlestoredb/tests/test_plugin.py
+++ b/singlestoredb/tests/test_plugin.py
@@ -252,6 +252,20 @@ class TestControlSignalDispatch(unittest.TestCase):
         assert body['code'] == 'REGISTER_FUNC_NOT_DYNAMIC'
         assert 'not a dynamically registered function' in body['message']
 
+    def test_register_unexpected_internal_error(self):
+        shared = self._make_shared_registry()
+        shared.create_function.side_effect = RuntimeError(
+            'simulated infrastructure failure',
+        )
+        payload = json.dumps({
+            'name': 'f', 'args': [], 'returns': [], 'body': 'x',
+        }).encode()
+        result = dispatch_control_signal('@@register', payload, shared)
+        assert result.ok is False
+        body = json.loads(result.data)
+        assert body['code'] == 'INTERNAL_ERROR'
+        assert 'simulated infrastructure failure' in body['message']
+
     def test_delete_missing_payload(self):
         shared = self._make_shared_registry()
         result = dispatch_control_signal('@@delete', b'', shared)


### PR DESCRIPTION
## Summary

- Adds the ADR 0001 error-code shape (`{\"message\": ..., \"code\": ...}`) to control-signal error responses in the Python plugin UDF server, matching the Rust wasm-udf-server.
- Maps each error site in `@@register` and `@@delete` to a stable code: `REGISTER_MISSING_PAYLOAD`, `REGISTER_INVALID_PAYLOAD`, `REGISTER_FUNC_EXISTS`, `DELETE_MISSING_PAYLOAD`, `DELETE_INVALID_PAYLOAD`, `DELETE_FUNC_NOT_FOUND`, `DELETE_FUNC_NOT_REGISTERED`, plus `UNKNOWN_SIGNAL` for unrecognised `@@`-prefixed signals.
- `REGISTER_DISABLED` / `DELETE_DISABLED` from the ADR catalog have no call site here because this server has no enable-register flag — noted in the module docstring.

## Test plan

- [x] \`pre-commit run --files\` clean on both modified files
- [x] \`pytest singlestoredb/tests/test_plugin.py\` — 44/44 passing, including new \`test_register_func_exists\` and updated assertions that parse \`result.data\` as JSON and check both \`code\` and \`message\`
- [ ] Manual wire spot-check from a downstream consumer once they pick up the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for clients that parsed plain-text control errors; behavior of register/delete against built-in names is stricter and error classification changed.
> 
> **Overview**
> Plugin UDF **control-signal failures** now return ADR 0001 JSON (`{"error":"...","code":"..."}`) instead of plain text, via a shared `_err()` helper in `control.py`, aligned with the Rust wasm-udf-server.
> 
> **`@@register` / `@@delete`** map registry and validation failures to stable codes (`REGISTER_*`, `DELETE_*`, `UNKNOWN_SIGNAL`, `INTERNAL_ERROR`). Handlers add stricter payload checks (JSON object, string `name`/`body`, boolean `replace`, `UnicodeDecodeError` on parse). Registry work adds `FunctionExistsError`, `FunctionNotDynamicError`, and `FunctionNotFoundError`, validates `args`/`returns` shape in `create_function`, and **rejects any registration whose name collides with a built-in** (not only `replace=true`). `SharedRegistry.delete_function` raises those types so delete errors no longer misclassify as `DELETE_INVALID_PAYLOAD`.
> 
> Tests assert parsed `code`/`error` and add integration coverage for end-to-end delete error codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd3190a9aed7967ccac74c28f7089341c87d9f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->