### PR TITLE
Update CODEOWNERS and stabilize fusion workspace-group drop test

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 * @kesmit13
-* @srinathnarayanan
+* @mgiannakopoulos
+* @volodymyr-memsql
+* @pmishchenko-ua

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-* @kesmit13
-* @mgiannakopoulos
-* @volodymyr-memsql
-* @pmishchenko-ua
+* @kesmit13 @mgiannakopoulos @volodymyr-memsql @pmishchenko-ua

--- a/singlestoredb/tests/test_fusion.py
+++ b/singlestoredb/tests/test_fusion.py
@@ -444,7 +444,10 @@ class TestWorkspaceFusion(unittest.TestCase):
                 f'create workspace group "{wg_name}" '
                 f'in region "{reg.name}"',
             )
-            wg = [x for x in mgr.workspace_groups if x.name == wg_name]
+            wg = [
+                x for x in mgr.workspace_groups
+                if x.name == wg_name and x.terminated_at is None
+            ]
             assert len(wg) == 1
 
             # Drop it by name
@@ -458,7 +461,10 @@ class TestWorkspaceFusion(unittest.TestCase):
             self.cur.execute(
                 f'create workspace group "{wg_name}" in region "{reg.name}"',
             )
-            wg = [x for x in mgr.workspace_groups if x.name == wg_name]
+            wg = [
+                x for x in mgr.workspace_groups
+                if x.name == wg_name and x.terminated_at is None
+            ]
             assert len(wg) == 1
 
             # Drop it by ID

--- a/singlestoredb/tests/test_fusion.py
+++ b/singlestoredb/tests/test_fusion.py
@@ -417,6 +417,22 @@ class TestWorkspaceFusion(unittest.TestCase):
             f'in group "A Fusion Testing {self.id}"',
         )
 
+    def _wait_workspace_group_gone(self, mgr, wg_name, timeout=60, interval=2):
+        # WAIT ON TERMINATED polls /workspaceGroups/{id}; the LIST endpoint
+        # /workspaceGroups can lag briefly behind it, so poll until the listed
+        # record is either absent or shows terminated_at.
+        deadline = time.time() + timeout
+        while True:
+            wg = [x for x in mgr.workspace_groups if x.name == wg_name]
+            if not wg or all(x.terminated_at is not None for x in wg):
+                return
+            if time.time() >= deadline:
+                self.fail(
+                    f'workspace group {wg_name!r} still active in list endpoint '
+                    f'after {timeout}s: {wg!r}',
+                )
+            time.sleep(interval)
+
     def test_create_drop_workspace_group(self):
         mgr = s2.manage_workspaces()
 
@@ -436,8 +452,7 @@ class TestWorkspaceFusion(unittest.TestCase):
                 f'drop workspace group "{wg_name}" '
                 'wait on terminated',
             )
-            wg = [x for x in mgr.workspace_groups if x.name == wg_name]
-            assert len(wg) == 0
+            self._wait_workspace_group_gone(mgr, wg_name)
 
             # Create it again
             self.cur.execute(
@@ -449,8 +464,7 @@ class TestWorkspaceFusion(unittest.TestCase):
             # Drop it by ID
             wg_id = wg[0].id
             self.cur.execute(f'drop workspace group id {wg_id} wait on terminated')
-            wg = [x for x in mgr.workspace_groups if x.name == wg_name]
-            assert len(wg) == 0
+            self._wait_workspace_group_gone(mgr, wg_name)
 
             # Drop non-existent
             with self.assertRaises(KeyError):


### PR DESCRIPTION
## Summary
- Replace `@srinathnarayanan` with `@mgiannakopoulos`, `@volodymyr-memsql`, and `@pmishchenko-ua` in CODEOWNERS.
- Stabilize `test_create_drop_workspace_group` by polling the workspace-groups list until the dropped group is gone or marked terminated, instead of asserting immediately after `WAIT ON TERMINATED` (the list endpoint can lag behind the per-resource endpoint).

## Test plan
- [ ] CI runs `pytest singlestoredb/tests/test_fusion.py::TestWorkspaceFusion::test_create_drop_workspace_group` and it passes consistently.
- [ ] Confirm CODEOWNERS changes route reviews to the new owners on a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CODEOWNERS routing and fusion integration-test timing/assertions change; no production library or API behavior.
> 
> **Overview**
> Updates **CODEOWNERS** so the default owner line is a single entry: `@kesmit13` stays, `@srinathnarayanan` is removed, and `@mgiannakopoulos`, `@volodymyr-memsql`, and `@pmishchenko-ua` are added.
> 
> **`test_create_drop_workspace_group`** is adjusted for eventual consistency between `WAIT ON TERMINATED` (per-group API) and `mgr.workspace_groups` (list API). A new **`_wait_workspace_group_gone`** helper polls for up to 60s until the group is missing from the list or every matching row has **`terminated_at`** set. Post-drop checks use that helper instead of asserting an empty list immediately; post-create checks only count groups with **`terminated_at is None`** so stale terminated rows do not break assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bedbb8c7a8bcaf107ab7ff33e23d1fdb3fa6cfa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->