### PR TITLE
embeddings: default check_embedding_ctx_length=False for OpenAI-compa…

### DIFF
--- a/singlestoredb/ai/embeddings.py
+++ b/singlestoredb/ai/embeddings.py
@@ -1,7 +1,9 @@
 import os
 from typing import Any
 from typing import Callable
+from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import httpx
@@ -28,6 +30,88 @@ except ImportError:
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
+
+
+class _ChunkedOpenAIEmbeddings(OpenAIEmbeddings):
+    """OpenAIEmbeddings for non-OpenAI models behind an OpenAI-compatible endpoint.
+
+    These models (e.g. Qwen served on the 'Nova' platform) tokenize server-side with
+    their own tokenizer, so inputs are sent as raw text (``check_embedding_ctx_length``
+    should be False). Because the server rejects (or silently truncates) inputs longer
+    than its context window, this class splits long inputs into character-bounded chunks
+    itself, embeds each chunk, and length-weighted-averages them back into a single
+    vector per input -- irrespective of the flag -- so long texts never hit the server's
+    hard limit.
+    """
+
+    max_chunk_chars: int = 24000
+    """Maximum characters per chunk. Conservative (~6-8k tokens for typical text) so a
+    chunk fits even deployments capped at 8192 tokens. Override per model if the
+    deployment's context window is known to be larger."""
+
+    def _chunks(self, text: str) -> List[str]:
+        n = max(1, self.max_chunk_chars)
+        if len(text) <= n:
+            return [text]
+        return [text[i:i + n] for i in range(0, len(text), n)]
+
+    @staticmethod
+    def _average(vectors: List[List[float]], weights: List[int]) -> List[float]:
+        total = float(sum(weights)) or 1.0
+        dim = len(vectors[0])
+        avg = [0.0] * dim
+        for vec, w in zip(vectors, weights):
+            for k in range(dim):
+                avg[k] += vec[k] * w
+        avg = [x / total for x in avg]
+        norm = sum(x * x for x in avg) ** 0.5
+        if norm > 0:
+            avg = [x / norm for x in avg]
+        return avg
+
+    def _plan(self, texts: List[str]) -> Tuple[List[str], List[int]]:
+        flat: List[str] = []
+        owner: List[int] = []
+        for i, text in enumerate(texts):
+            for chunk in self._chunks(text):
+                flat.append(chunk)
+                owner.append(i)
+        return flat, owner
+
+    def _reduce(
+        self,
+        num_texts: int,
+        owner: List[int],
+        flat: List[str],
+        embeddings: List[List[float]],
+    ) -> List[List[float]]:
+        out: List[List[float]] = []
+        for i in range(num_texts):
+            idxs = [j for j, o in enumerate(owner) if o == i]
+            if len(idxs) == 1:
+                out.append(embeddings[idxs[0]])
+            else:
+                out.append(
+                    self._average(
+                        [embeddings[j] for j in idxs],
+                        [max(1, len(flat[j])) for j in idxs],
+                    ),
+                )
+        return out
+
+    def embed_documents(
+        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any,
+    ) -> List[List[float]]:
+        flat, owner = self._plan(texts)
+        embeddings = super().embed_documents(flat, chunk_size=chunk_size, **kwargs)
+        return self._reduce(len(texts), owner, flat, embeddings)
+
+    async def aembed_documents(
+        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any,
+    ) -> List[List[float]]:
+        flat, owner = self._plan(texts)
+        embeddings = await super().aembed_documents(flat, chunk_size=chunk_size, **kwargs)
+        return self._reduce(len(texts), owner, flat, embeddings)
 
 
 def SingleStoreEmbeddingsFactory(
@@ -152,14 +236,23 @@ def SingleStoreEmbeddingsFactory(
     )
     if http_client is not None:
         openai_kwargs['http_client'] = http_client
-    # Genuine OpenAI/Azure models tokenize with tiktoken correctly, so keep langchain's
-    # default (client-side tokenization + long-input chunking). For every other platform
-    # (e.g. 'Nova' self-hosted models like Qwen), tiktoken sends OpenAI token IDs instead
-    # of the raw text, which the model can't interpret -> nonsensical embeddings. For
-    # those, send raw text and let the server tokenize. Callers can override explicitly.
-    if info.hosting_platform not in ('Azure', 'OpenAI'):
-        kwargs.setdefault('check_embedding_ctx_length', False)
-    return OpenAIEmbeddings(
+
+    if info.hosting_platform == 'Azure':
+        # Genuine OpenAI (Azure) models: tiktoken is the correct tokenizer, and the
+        # model name is passed above so it selects the right encoding. Keep langchain's
+        # client-side tokenization + long-input chunking (all correct for these models).
+        kwargs.setdefault('check_embedding_ctx_length', True)
+        return OpenAIEmbeddings(
+            **openai_kwargs,
+            **kwargs,
+        )
+
+    # Non-OpenAI models (e.g. Qwen on 'Nova'): tiktoken would send OpenAI token IDs the
+    # model can't interpret -> nonsensical embeddings. Send raw text so the server
+    # tokenizes with the model's own tokenizer, and chunk long inputs ourselves (the
+    # server otherwise rejects or silently truncates over-context input).
+    kwargs.setdefault('check_embedding_ctx_length', False)
+    return _ChunkedOpenAIEmbeddings(
         **openai_kwargs,
         **kwargs,
     )

--- a/singlestoredb/ai/embeddings.py
+++ b/singlestoredb/ai/embeddings.py
@@ -1,7 +1,9 @@
 import os
 from typing import Any
 from typing import Callable
+from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import httpx
@@ -28,6 +30,88 @@ except ImportError:
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
+
+
+class _ChunkedOpenAIEmbeddings(OpenAIEmbeddings):
+    """OpenAIEmbeddings for non-OpenAI models behind an OpenAI-compatible endpoint.
+
+    These models (e.g. Qwen served on the 'Nova' platform) tokenize server-side with
+    their own tokenizer, so inputs are sent as raw text (``check_embedding_ctx_length``
+    should be False). Because the server rejects (or silently truncates) inputs longer
+    than its context window, this class splits long inputs into character-bounded chunks
+    itself, embeds each chunk, and length-weighted-averages them back into a single
+    vector per input -- irrespective of the flag -- so long texts never hit the server's
+    hard limit.
+    """
+
+    max_chunk_chars: int = 24000
+    """Maximum characters per chunk. Conservative (~6-8k tokens for typical text) so a
+    chunk fits even deployments capped at 8192 tokens. Override per model if the
+    deployment's context window is known to be larger."""
+
+    def _chunks(self, text: str) -> List[str]:
+        n = max(1, self.max_chunk_chars)
+        if len(text) <= n:
+            return [text]
+        return [text[i:i + n] for i in range(0, len(text), n)]
+
+    @staticmethod
+    def _average(vectors: List[List[float]], weights: List[int]) -> List[float]:
+        total = float(sum(weights)) or 1.0
+        dim = len(vectors[0])
+        avg = [0.0] * dim
+        for vec, w in zip(vectors, weights):
+            for k in range(dim):
+                avg[k] += vec[k] * w
+        avg = [x / total for x in avg]
+        norm = sum(x * x for x in avg) ** 0.5
+        if norm > 0:
+            avg = [x / norm for x in avg]
+        return avg
+
+    def _plan(self, texts: List[str]) -> Tuple[List[str], List[int]]:
+        flat: List[str] = []
+        owner: List[int] = []
+        for i, text in enumerate(texts):
+            for chunk in self._chunks(text):
+                flat.append(chunk)
+                owner.append(i)
+        return flat, owner
+
+    def _reduce(
+        self,
+        num_texts: int,
+        owner: List[int],
+        flat: List[str],
+        embeddings: List[List[float]],
+    ) -> List[List[float]]:
+        out: List[List[float]] = []
+        for i in range(num_texts):
+            idxs = [j for j, o in enumerate(owner) if o == i]
+            if len(idxs) == 1:
+                out.append(embeddings[idxs[0]])
+            else:
+                out.append(
+                    self._average(
+                        [embeddings[j] for j in idxs],
+                        [max(1, len(flat[j])) for j in idxs],
+                    ),
+                )
+        return out
+
+    def embed_documents(
+        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any,
+    ) -> List[List[float]]:
+        flat, owner = self._plan(texts)
+        embeddings = super().embed_documents(flat, chunk_size=chunk_size, **kwargs)
+        return self._reduce(len(texts), owner, flat, embeddings)
+
+    async def aembed_documents(
+        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any,
+    ) -> List[List[float]]:
+        flat, owner = self._plan(texts)
+        embeddings = await super().aembed_documents(flat, chunk_size=chunk_size, **kwargs)
+        return self._reduce(len(texts), owner, flat, embeddings)
 
 
 def SingleStoreEmbeddingsFactory(
@@ -153,15 +237,22 @@ def SingleStoreEmbeddingsFactory(
     if http_client is not None:
         openai_kwargs['http_client'] = http_client
 
-    # Azure (OpenAI) models tokenize correctly with tiktoken using the model name passed
-    # above, so keep langchain's default client-side tokenization. Every other platform
-    # (e.g. Qwen on 'Nova') would get wrong tiktoken token IDs, so send raw text and let
-    # the server tokenize with the model's own tokenizer.
     if info.hosting_platform == 'Azure':
+        # Genuine OpenAI (Azure) models: tiktoken is the correct tokenizer, and the
+        # model name is passed above so it selects the right encoding. Keep langchain's
+        # client-side tokenization + long-input chunking (all correct for these models).
         kwargs.setdefault('check_embedding_ctx_length', True)
-    else:
-        kwargs.setdefault('check_embedding_ctx_length', False)
-    return OpenAIEmbeddings(
+        return OpenAIEmbeddings(
+            **openai_kwargs,
+            **kwargs,
+        )
+
+    # Non-OpenAI models (e.g. Qwen on 'Nova'): tiktoken would send OpenAI token IDs the
+    # model can't interpret -> nonsensical embeddings. Send raw text so the server
+    # tokenizes with the model's own tokenizer, and chunk long inputs ourselves (the
+    # server otherwise rejects or silently truncates over-context input).
+    kwargs.setdefault('check_embedding_ctx_length', False)
+    return _ChunkedOpenAIEmbeddings(
         **openai_kwargs,
         **kwargs,
     )

--- a/singlestoredb/ai/embeddings.py
+++ b/singlestoredb/ai/embeddings.py
@@ -152,13 +152,13 @@ def SingleStoreEmbeddingsFactory(
     )
     if http_client is not None:
         openai_kwargs['http_client'] = http_client
-    # Non-OpenAI models behind an OpenAI-compatible endpoint (e.g. Qwen) get wrong
-    # embeddings under langchain's default client-side tiktoken tokenization, which
-    # sends OpenAI token IDs instead of raw text. Default to raw text so the server
-    # tokenizes correctly; this is a no-op for genuine OpenAI models. Callers can
-    # opt back in with check_embedding_ctx_length=True. Scoped to this OpenAI path;
-    # the Bedrock branch above never receives this kwarg.
-    kwargs.setdefault('check_embedding_ctx_length', False)
+    # Genuine OpenAI/Azure models tokenize with tiktoken correctly, so keep langchain's
+    # default (client-side tokenization + long-input chunking). For every other platform
+    # (e.g. 'Nova' self-hosted models like Qwen), tiktoken sends OpenAI token IDs instead
+    # of the raw text, which the model can't interpret -> nonsensical embeddings. For
+    # those, send raw text and let the server tokenize. Callers can override explicitly.
+    if info.hosting_platform not in ('Azure', 'OpenAI'):
+        kwargs.setdefault('check_embedding_ctx_length', False)
     return OpenAIEmbeddings(
         **openai_kwargs,
         **kwargs,

--- a/singlestoredb/ai/embeddings.py
+++ b/singlestoredb/ai/embeddings.py
@@ -45,9 +45,10 @@ class _ChunkedOpenAIEmbeddings(OpenAIEmbeddings):
     """
 
     max_chunk_chars: int = 24000
-    """Maximum characters per chunk. Conservative (~6-8k tokens for typical text) so a
-    chunk fits even deployments capped at 8192 tokens. Override per model if the
-    deployment's context window is known to be larger."""
+    """Maximum characters per chunk. This is a coarse character-based guard for
+    models whose exact tokenizer/context metadata is not yet available to the client.
+    Override per model if the deployment's context window is known to be smaller or
+    larger."""
 
     def _chunks(self, text: str) -> List[str]:
         n = max(1, self.max_chunk_chars)

--- a/singlestoredb/ai/embeddings.py
+++ b/singlestoredb/ai/embeddings.py
@@ -1,9 +1,7 @@
 import os
 from typing import Any
 from typing import Callable
-from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Union
 
 import httpx
@@ -30,88 +28,6 @@ except ImportError:
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config
-
-
-class _ChunkedOpenAIEmbeddings(OpenAIEmbeddings):
-    """OpenAIEmbeddings for non-OpenAI models behind an OpenAI-compatible endpoint.
-
-    These models (e.g. Qwen served on the 'Nova' platform) tokenize server-side with
-    their own tokenizer, so inputs are sent as raw text (``check_embedding_ctx_length``
-    should be False). Because the server rejects (or silently truncates) inputs longer
-    than its context window, this class splits long inputs into character-bounded chunks
-    itself, embeds each chunk, and length-weighted-averages them back into a single
-    vector per input -- irrespective of the flag -- so long texts never hit the server's
-    hard limit.
-    """
-
-    max_chunk_chars: int = 24000
-    """Maximum characters per chunk. Conservative (~6-8k tokens for typical text) so a
-    chunk fits even deployments capped at 8192 tokens. Override per model if the
-    deployment's context window is known to be larger."""
-
-    def _chunks(self, text: str) -> List[str]:
-        n = max(1, self.max_chunk_chars)
-        if len(text) <= n:
-            return [text]
-        return [text[i:i + n] for i in range(0, len(text), n)]
-
-    @staticmethod
-    def _average(vectors: List[List[float]], weights: List[int]) -> List[float]:
-        total = float(sum(weights)) or 1.0
-        dim = len(vectors[0])
-        avg = [0.0] * dim
-        for vec, w in zip(vectors, weights):
-            for k in range(dim):
-                avg[k] += vec[k] * w
-        avg = [x / total for x in avg]
-        norm = sum(x * x for x in avg) ** 0.5
-        if norm > 0:
-            avg = [x / norm for x in avg]
-        return avg
-
-    def _plan(self, texts: List[str]) -> Tuple[List[str], List[int]]:
-        flat: List[str] = []
-        owner: List[int] = []
-        for i, text in enumerate(texts):
-            for chunk in self._chunks(text):
-                flat.append(chunk)
-                owner.append(i)
-        return flat, owner
-
-    def _reduce(
-        self,
-        num_texts: int,
-        owner: List[int],
-        flat: List[str],
-        embeddings: List[List[float]],
-    ) -> List[List[float]]:
-        out: List[List[float]] = []
-        for i in range(num_texts):
-            idxs = [j for j, o in enumerate(owner) if o == i]
-            if len(idxs) == 1:
-                out.append(embeddings[idxs[0]])
-            else:
-                out.append(
-                    self._average(
-                        [embeddings[j] for j in idxs],
-                        [max(1, len(flat[j])) for j in idxs],
-                    ),
-                )
-        return out
-
-    def embed_documents(
-        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any,
-    ) -> List[List[float]]:
-        flat, owner = self._plan(texts)
-        embeddings = super().embed_documents(flat, chunk_size=chunk_size, **kwargs)
-        return self._reduce(len(texts), owner, flat, embeddings)
-
-    async def aembed_documents(
-        self, texts: List[str], chunk_size: Optional[int] = None, **kwargs: Any,
-    ) -> List[List[float]]:
-        flat, owner = self._plan(texts)
-        embeddings = await super().aembed_documents(flat, chunk_size=chunk_size, **kwargs)
-        return self._reduce(len(texts), owner, flat, embeddings)
 
 
 def SingleStoreEmbeddingsFactory(
@@ -237,22 +153,15 @@ def SingleStoreEmbeddingsFactory(
     if http_client is not None:
         openai_kwargs['http_client'] = http_client
 
+    # Azure (OpenAI) models tokenize correctly with tiktoken using the model name passed
+    # above, so keep langchain's default client-side tokenization. Every other platform
+    # (e.g. Qwen on 'Nova') would get wrong tiktoken token IDs, so send raw text and let
+    # the server tokenize with the model's own tokenizer.
     if info.hosting_platform == 'Azure':
-        # Genuine OpenAI (Azure) models: tiktoken is the correct tokenizer, and the
-        # model name is passed above so it selects the right encoding. Keep langchain's
-        # client-side tokenization + long-input chunking (all correct for these models).
         kwargs.setdefault('check_embedding_ctx_length', True)
-        return OpenAIEmbeddings(
-            **openai_kwargs,
-            **kwargs,
-        )
-
-    # Non-OpenAI models (e.g. Qwen on 'Nova'): tiktoken would send OpenAI token IDs the
-    # model can't interpret -> nonsensical embeddings. Send raw text so the server
-    # tokenizes with the model's own tokenizer, and chunk long inputs ourselves (the
-    # server otherwise rejects or silently truncates over-context input).
-    kwargs.setdefault('check_embedding_ctx_length', False)
-    return _ChunkedOpenAIEmbeddings(
+    else:
+        kwargs.setdefault('check_embedding_ctx_length', False)
+    return OpenAIEmbeddings(
         **openai_kwargs,
         **kwargs,
     )

--- a/singlestoredb/ai/embeddings.py
+++ b/singlestoredb/ai/embeddings.py
@@ -152,6 +152,13 @@ def SingleStoreEmbeddingsFactory(
     )
     if http_client is not None:
         openai_kwargs['http_client'] = http_client
+    # Non-OpenAI models behind an OpenAI-compatible endpoint (e.g. Qwen) get wrong
+    # embeddings under langchain's default client-side tiktoken tokenization, which
+    # sends OpenAI token IDs instead of raw text. Default to raw text so the server
+    # tokenizes correctly; this is a no-op for genuine OpenAI models. Callers can
+    # opt back in with check_embedding_ctx_length=True. Scoped to this OpenAI path;
+    # the Bedrock branch above never receives this kwarg.
+    kwargs.setdefault('check_embedding_ctx_length', False)
     return OpenAIEmbeddings(
         **openai_kwargs,
         **kwargs,

--- a/singlestoredb/tests/test_embeddings.py
+++ b/singlestoredb/tests/test_embeddings.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# type: ignore
+"""SingleStoreDB embeddings testing."""
+import asyncio
+import importlib.util
+import math
+import os
+import sys
+import types
+import unittest
+
+
+class MockOpenAIEmbeddings:
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.seen_documents = []
+        self.async_seen_documents = []
+
+    @staticmethod
+    def _embedding_for(text):
+        if text.startswith('a'):
+            return [1.0, 0.0]
+        if text.startswith('b'):
+            return [0.0, 1.0]
+        return [0.0, -1.0]
+
+    def embed_documents(self, texts, chunk_size=None, **kwargs):
+        self.seen_documents.extend(texts)
+        self.seen_chunk_size = chunk_size
+        self.seen_kwargs = kwargs
+        return [self._embedding_for(text) for text in texts]
+
+    async def aembed_documents(self, texts, chunk_size=None, **kwargs):
+        self.async_seen_documents.extend(texts)
+        self.async_seen_chunk_size = chunk_size
+        self.async_seen_kwargs = kwargs
+        return [self._embedding_for(text) for text in texts]
+
+
+class MockBedrockEmbeddings:
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class MockConfig:
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class MockClient:
+    pass
+
+
+class MockTimeout:
+
+    def __init__(self, connect=None, read=None):
+        self.connect = connect
+        self.read = read
+
+
+class MockBoto3(types.ModuleType):
+
+    def client(self, *args, **kwargs):
+        return types.SimpleNamespace(
+            _endpoint=types.SimpleNamespace(
+                _event_emitter=types.SimpleNamespace(
+                    register_first=lambda *args, **kwargs: None,
+                ),
+            ),
+        )
+
+
+class TestEmbeddings(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        sys.modules.pop('singlestoredb.ai.embeddings', None)
+        sys.modules.pop('_test_embeddings_module', None)
+
+        httpx = types.ModuleType('httpx')
+        httpx.Client = MockClient
+        httpx.Timeout = MockTimeout
+        sys.modules['httpx'] = httpx
+
+        langchain_openai = types.ModuleType('langchain_openai')
+        langchain_openai.OpenAIEmbeddings = MockOpenAIEmbeddings
+        sys.modules['langchain_openai'] = langchain_openai
+
+        langchain_aws = types.ModuleType('langchain_aws')
+        langchain_aws.BedrockEmbeddings = MockBedrockEmbeddings
+        sys.modules['langchain_aws'] = langchain_aws
+
+        botocore = types.ModuleType('botocore')
+        botocore.UNSIGNED = 'unsigned'
+        sys.modules['botocore'] = botocore
+
+        botocore_config = types.ModuleType('botocore.config')
+        botocore_config.Config = MockConfig
+        sys.modules['botocore.config'] = botocore_config
+
+        sys.modules['boto3'] = MockBoto3('boto3')
+
+        path = os.path.join(os.path.dirname(__file__), '..', 'ai', 'embeddings.py')
+        spec = importlib.util.spec_from_file_location('_test_embeddings_module', path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules['_test_embeddings_module'] = module
+        assert spec.loader is not None, spec
+        spec.loader.exec_module(module)
+        cls.embeddings = module
+
+    def test_non_azure_factory_sends_raw_strings_and_uses_chunk_cap(self):
+        embedding = self.embeddings.SingleStoreEmbeddingsFactory(
+            model_name='shared-qwen3-embed-0-6b',
+            api_key='token',
+            base_url='http://localhost:8000',
+            hosting_platform='NovaMultiTenant',
+        )
+
+        assert isinstance(embedding, self.embeddings._ChunkedOpenAIEmbeddings)
+        assert embedding.kwargs['check_embedding_ctx_length'] is False
+        assert embedding.max_chunk_chars == 24000, embedding.max_chunk_chars
+
+        embedding.embed_documents(['a' * 24001])
+        assert [len(x) for x in embedding.seen_documents] == [24000, 1]
+
+    def test_azure_factory_keeps_langchain_tokenization(self):
+        embedding = self.embeddings.SingleStoreEmbeddingsFactory(
+            model_name='text-embedding-3-small',
+            api_key='token',
+            base_url='http://localhost:8000',
+            hosting_platform='Azure',
+        )
+
+        assert isinstance(embedding, MockOpenAIEmbeddings)
+        assert not isinstance(embedding, self.embeddings._ChunkedOpenAIEmbeddings)
+        assert embedding.kwargs['check_embedding_ctx_length'] is True
+
+    def test_chunked_embedding_reduces_weighted_average_to_one_vector(self):
+        embedding = self.embeddings._ChunkedOpenAIEmbeddings(
+            model='shared-qwen3-embed-0-6b',
+            api_key='token',
+            base_url='http://localhost:8000',
+            check_embedding_ctx_length=False,
+        )
+        embedding.max_chunk_chars = 3
+
+        out = embedding.embed_documents(['aaabbb', 'zz'])
+
+        assert embedding.seen_documents == ['aaa', 'bbb', 'zz']
+        assert len(out) == 2, out
+        assert math.isclose(out[0][0], 1.0 / math.sqrt(2.0)), out[0]
+        assert math.isclose(out[0][1], 1.0 / math.sqrt(2.0)), out[0]
+        assert out[1] == [0.0, -1.0], out[1]
+
+    def test_async_chunked_embedding_uses_same_reduction(self):
+        async def run():
+            embedding = self.embeddings._ChunkedOpenAIEmbeddings(
+                model='shared-qwen3-embed-0-6b',
+                api_key='token',
+                base_url='http://localhost:8000',
+                check_embedding_ctx_length=False,
+            )
+            embedding.max_chunk_chars = 3
+
+            out = await embedding.aembed_documents(['aaabbb'])
+
+            assert embedding.async_seen_documents == ['aaa', 'bbb']
+            assert len(out) == 1, out
+            assert math.isclose(out[0][0], 1.0 / math.sqrt(2.0)), out[0]
+            assert math.isclose(out[0][1], 1.0 / math.sqrt(2.0)), out[0]
+
+        asyncio.run(run())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Don’t use OpenAI’s tokenizer for Qwen** — LangChain’s default (check_embedding_ctx_length=True) turns text into OpenAI token IDs. Qwen can’t read those, so embeddings are garbage. Send raw text instead (False) so the server tokenizes correctly.

**Keep OpenAI/Azure on the default** — Real OpenAI/Azure models still use True (tiktoken + LangChain’s built-in long-text handling). Only non-OpenAI/Nova models get the raw-text default.

**Chunk long Qwen inputs ourselves** — With raw text, LangChain won’t split long docs, so the server 400s or truncates. For those models, split into character chunks, embed each, then average into one vector so long text still works.

Test cases:
1. 
Before:
label	cosine_vs_anchor
anchor	1.0
unrelated2	0.3536
same_intent	0.3461
paraphrase	0.304
unrelated	0.2523

After
<img width="1438" height="1082" alt="image" src="https://github.com/user-attachments/assets/1e33c6e5-56db-494f-a271-7b9f50d45e3e" />

2.
Chunking Long Text 
<img width="1438" height="1082" alt="Screenshot from 2026-07-22 21-56-26" src="https://github.com/user-attachments/assets/d0726eb2-de6c-470d-9a14-1bb7db386abc" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default embedding behavior for all non-Azure OpenAI-compatible inference paths, which can alter vector quality and similarity for existing Nova/Qwen workloads but fixes incorrect embeddings from wrong tokenization.
> 
> **Overview**
> **Fixes broken embeddings for OpenAI-compatible non-Azure models** (e.g. Qwen on Nova) by stopping LangChain’s tiktoken path: `SingleStoreEmbeddingsFactory` now defaults `check_embedding_ctx_length=False` and returns `_ChunkedOpenAIEmbeddings` so the server receives raw text and tokenizes with the model’s own tokenizer.
> 
> **Azure-hosted OpenAI models are unchanged** — they still use stock `OpenAIEmbeddings` with `check_embedding_ctx_length=True` and LangChain’s built-in context handling.
> 
> **Long inputs on Nova-style models** are split into ~24k-character chunks, embedded per chunk, then merged via length-weighted averaging and L2 normalization into one vector per document (sync and async `embed_documents`). Unit tests cover factory branching, chunk splitting, and reduction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cf344cb51e5b20ba7bc66d1807b669919cc9542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->