### PR TITLE
Propagate OpenTelemetry context on inference API calls MCDB-100371

### DIFF
--- a/singlestoredb/ai/chat.py
+++ b/singlestoredb/ai/chat.py
@@ -187,7 +187,7 @@ def SingleStoreChatFactory(
         streaming=streaming,
     )
     http_async_client = kwargs.pop('http_async_client', None)
-    default_timeout = httpx.Timeout(600.0)
+    default_timeout = httpx.Timeout(timeout=600.0, connect=5.0)
     if http_client is None:
         http_client = httpx.Client(timeout=default_timeout)
     _attach_otel_request_hook(http_client)

--- a/singlestoredb/ai/chat.py
+++ b/singlestoredb/ai/chat.py
@@ -9,6 +9,30 @@ import httpx
 from singlestoredb import manage_workspaces
 from singlestoredb.management.inference_api import InferenceAPIInfo
 
+
+def _inject_otel_headers(headers: Any) -> None:
+    try:
+        from opentelemetry.propagate import inject as otel_inject
+    except ImportError:
+        return
+    try:
+        otel_inject(headers)
+    except Exception:
+        return
+
+
+def _httpx_inject_otel(request: httpx.Request) -> None:
+    _inject_otel_headers(request.headers)
+
+
+def _attach_otel_request_hook(
+    client: Union[httpx.Client, httpx.AsyncClient],
+) -> None:
+    hooks = client.event_hooks.setdefault('request', [])
+    if _httpx_inject_otel not in hooks:
+        hooks.append(_httpx_inject_otel)
+
+
 try:
     from langchain_openai import ChatOpenAI
 except ImportError:
@@ -119,6 +143,7 @@ def SingleStoreChatFactory(
                 obo_val = obo_token_getter()
                 if obo_val:
                     request.headers['X-S2-OBO'] = obo_val
+            _inject_otel_headers(request.headers)
             request.headers.pop('X-Amz-Date', None)
             request.headers.pop('X-Amz-Security-Token', None)
 
@@ -161,8 +186,15 @@ def SingleStoreChatFactory(
         model=model_name,
         streaming=streaming,
     )
-    if http_client is not None:
-        openai_kwargs['http_client'] = http_client
+    http_async_client = kwargs.pop('http_async_client', None)
+    if http_client is None:
+        http_client = httpx.Client(timeout=httpx.Timeout(None))
+    _attach_otel_request_hook(http_client)
+    openai_kwargs['http_client'] = http_client
+    if http_async_client is None:
+        http_async_client = httpx.AsyncClient(timeout=httpx.Timeout(None))
+    _attach_otel_request_hook(http_async_client)
+    openai_kwargs['http_async_client'] = http_async_client
     return ChatOpenAI(
         **openai_kwargs,
         **kwargs,

--- a/singlestoredb/ai/chat.py
+++ b/singlestoredb/ai/chat.py
@@ -10,6 +10,27 @@ from singlestoredb import manage_workspaces
 from singlestoredb.management.inference_api import InferenceAPIInfo
 
 
+try:
+    from langchain_openai import ChatOpenAI
+except ImportError:
+    raise ImportError(
+        'Could not import langchain_openai python package. '
+        'Please install it with `pip install langchain_openai`.',
+    )
+
+try:
+    from langchain_aws import ChatBedrockConverse
+except ImportError:
+    raise ImportError(
+        'Could not import langchain-aws python package. '
+        'Please install it with `pip install langchain-aws`.',
+    )
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+
+
 def _inject_otel_headers(headers: Any) -> None:
     try:
         from opentelemetry.propagate import inject as otel_inject
@@ -31,27 +52,6 @@ def _attach_otel_request_hook(
     hooks = client.event_hooks.setdefault('request', [])
     if _httpx_inject_otel not in hooks:
         hooks.append(_httpx_inject_otel)
-
-
-try:
-    from langchain_openai import ChatOpenAI
-except ImportError:
-    raise ImportError(
-        'Could not import langchain_openai python package. '
-        'Please install it with `pip install langchain_openai`.',
-    )
-
-try:
-    from langchain_aws import ChatBedrockConverse
-except ImportError:
-    raise ImportError(
-        'Could not import langchain-aws python package. '
-        'Please install it with `pip install langchain-aws`.',
-    )
-
-import boto3
-from botocore import UNSIGNED
-from botocore.config import Config
 
 
 def SingleStoreChatFactory(

--- a/singlestoredb/ai/chat.py
+++ b/singlestoredb/ai/chat.py
@@ -187,12 +187,16 @@ def SingleStoreChatFactory(
         streaming=streaming,
     )
     http_async_client = kwargs.pop('http_async_client', None)
+    default_timeout = httpx.Timeout(600.0)
     if http_client is None:
-        http_client = httpx.Client(timeout=httpx.Timeout(None))
+        http_client = httpx.Client(timeout=default_timeout)
     _attach_otel_request_hook(http_client)
     openai_kwargs['http_client'] = http_client
     if http_async_client is None:
-        http_async_client = httpx.AsyncClient(timeout=httpx.Timeout(None))
+        async_timeout = (
+            http_client.timeout if http_client is not None else default_timeout
+        )
+        http_async_client = httpx.AsyncClient(timeout=async_timeout)
     _attach_otel_request_hook(http_async_client)
     openai_kwargs['http_async_client'] = http_async_client
     return ChatOpenAI(

--- a/singlestoredb/tests/test_ai_chat.py
+++ b/singlestoredb/tests/test_ai_chat.py
@@ -25,6 +25,7 @@ class TestInjectOtelHeaders(unittest.TestCase):
         fake_propagate = ModuleType('opentelemetry.propagate')
         fake_propagate.inject = fake_inject
         fake_otel = ModuleType('opentelemetry')
+        fake_otel.__path__ = []  # mark as package for submodules
         with patch.dict(
             'sys.modules',
             {
@@ -61,8 +62,10 @@ class TestInjectOtelHeaders(unittest.TestCase):
         try:
             self.assertIsNotNone(http_client)
             self.assertEqual(http_client.timeout.read, 600.0)
+            self.assertEqual(http_client.timeout.connect, 5.0)
             self.assertIsNotNone(http_async_client)
             self.assertEqual(http_async_client.timeout.read, 600.0)
+            self.assertEqual(http_async_client.timeout.connect, 5.0)
         finally:
             if http_client:
                 http_client.close()

--- a/singlestoredb/tests/test_ai_chat.py
+++ b/singlestoredb/tests/test_ai_chat.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# type: ignore
+"""SingleStoreChatFactory OTel header injection tests."""
+import unittest
+from types import ModuleType
+from unittest.mock import patch
+
+try:
+    import httpx
+    from singlestoredb.ai import chat as chat_mod
+except ImportError:
+    httpx = None
+    chat_mod = None
+
+
+@unittest.skipIf(chat_mod is None, 'singlestoredb.ai.chat dependencies missing')
+class TestInjectOtelHeaders(unittest.TestCase):
+
+    def test_calls_otel_inject(self):
+        headers = {}
+
+        def fake_inject(target):
+            target['baggage'] = 'session=abc,turn=def'
+
+        fake_propagate = ModuleType('opentelemetry.propagate')
+        fake_propagate.inject = fake_inject
+        fake_otel = ModuleType('opentelemetry')
+        with patch.dict(
+            'sys.modules',
+            {
+                'opentelemetry': fake_otel,
+                'opentelemetry.propagate': fake_propagate,
+            },
+        ):
+            chat_mod._inject_otel_headers(headers)
+        self.assertEqual(headers['baggage'], 'session=abc,turn=def')
+
+    def test_httpx_hook_appends_once(self):
+        client = httpx.Client()
+        try:
+            chat_mod._attach_otel_request_hook(client)
+            chat_mod._attach_otel_request_hook(client)
+            self.assertEqual(
+                client.event_hooks['request'].count(chat_mod._httpx_inject_otel),
+                1,
+            )
+        finally:
+            client.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/singlestoredb/tests/test_ai_chat.py
+++ b/singlestoredb/tests/test_ai_chat.py
@@ -47,12 +47,52 @@ class TestInjectOtelHeaders(unittest.TestCase):
         finally:
             client.close()
 
-    def test_openai_default_timeout_is_600(self):
-        client = httpx.Client(timeout=httpx.Timeout(600.0))
+    @patch('singlestoredb.ai.chat.ChatOpenAI')
+    def test_openai_default_timeout_is_600(self, mock_chat_openai):
+        chat_mod.SingleStoreChatFactory(
+            model_name='gpt-4o',
+            base_url='https://example.com',
+            hosting_platform='OpenAI',
+        )
+        self.assertTrue(mock_chat_openai.called)
+        _, kwargs = mock_chat_openai.call_args
+        http_client = kwargs.get('http_client')
+        http_async_client = kwargs.get('http_async_client')
         try:
-            self.assertEqual(client.timeout.read, 600.0)
+            self.assertIsNotNone(http_client)
+            self.assertEqual(http_client.timeout.read, 600.0)
+            self.assertIsNotNone(http_async_client)
+            self.assertEqual(http_async_client.timeout.read, 600.0)
         finally:
-            client.close()
+            if http_client:
+                http_client.close()
+            if http_async_client:
+                import asyncio
+                asyncio.run(http_async_client.aclose())
+
+    @patch('singlestoredb.ai.chat.ChatOpenAI')
+    def test_openai_inherits_custom_client_timeout(self, mock_chat_openai):
+        custom_sync = httpx.Client(timeout=httpx.Timeout(42.0))
+        http_async_client = None
+        try:
+            chat_mod.SingleStoreChatFactory(
+                model_name='gpt-4o',
+                base_url='https://example.com',
+                hosting_platform='OpenAI',
+                http_client=custom_sync,
+            )
+            self.assertTrue(mock_chat_openai.called)
+            _, kwargs = mock_chat_openai.call_args
+            http_client = kwargs.get('http_client')
+            http_async_client = kwargs.get('http_async_client')
+            self.assertIs(http_client, custom_sync)
+            self.assertIsNotNone(http_async_client)
+            self.assertEqual(http_async_client.timeout.read, 42.0)
+        finally:
+            custom_sync.close()
+            if http_async_client:
+                import asyncio
+                asyncio.run(http_async_client.aclose())
 
 
 if __name__ == '__main__':

--- a/singlestoredb/tests/test_ai_chat.py
+++ b/singlestoredb/tests/test_ai_chat.py
@@ -47,6 +47,13 @@ class TestInjectOtelHeaders(unittest.TestCase):
         finally:
             client.close()
 
+    def test_openai_default_timeout_is_600(self):
+        client = httpx.Client(timeout=httpx.Timeout(600.0))
+        try:
+            self.assertEqual(client.timeout.read, 600.0)
+        finally:
+            client.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

`SingleStoreChatFactory` now automatically propagates the active OpenTelemetry context (W3C `traceparent` and `baggage`) on outbound Unified Model Gateway (UMG) calls for both Bedrock and OpenAI/Azure clients.

- **Bedrock (`ChatBedrockConverse`)**: Registers an event hook on `before-send.bedrock-runtime.Converse` (and related Bedrock events) to inject active OTel trace headers into `request.headers`.
- **OpenAI (`ChatOpenAI`)**: Attaches an `httpx` request hook to `http_client` and `http_async_client` to inject headers on each request.
- **Context**: In-process agents (`s2ai`) mint `session` and `turn` IDs into OpenTelemetry baggage, but vanilla `boto3` and `httpx` clients do not serialize Python's OTel context into outbound HTTP requests without explicit event hooks. This caused `resourceusage` telemetry to omit `sessionId` and `turnId` for managed agents (Flow, Query Tuning, Observability, Support). Moving trace injection directly into `SingleStoreChatFactory` ensures all current and future agents automatically propagate session and turn attribution without needing per-agent boilerplate.

## Test Plan

- Unit tests in `singlestoredb/tests/test_ai_chat.py`:
  - `test_calls_otel_inject`: Verifies `_inject_otel_headers` calls `opentelemetry.propagate.inject` and writes baggage headers.
  - `test_httpx_hook_appends_once`: Verifies that attaching the request hook to an `httpx.Client` is idempotent and does not duplicate hooks.
- Lint and type checks: `pre-commit run --all-files` passes cleanly across all hooks (`flake8`, `mypy`, `autopep8`, `reorder-python-imports`).
- Live verification: Verified against UMG reverse proxy that inbound W3C baggage with `session` and `turn` correctly populates `sessionId` and `turnId` on `ModelBillingTags`.

## Deployment Plan

- Customer Impact: Low. Adds standard W3C trace/baggage HTTP headers on outbound inference API calls.
- Rollout Plan: Normal PyPI release. Picked up by Nova agent pool images on next build.
- Rollback Plan: Revert PR and publish patch release.

## JIRA Issues

MCDB-100371

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes add optional OTel HTTP headers and adjust default httpx client creation/timeouts for OpenAI chat; no auth or data-path logic changes, and OTel injection is a no-op when the library is absent.
> 
> **Overview**
> **`SingleStoreChatFactory`** now forwards the active OpenTelemetry context (W3C trace and baggage) on outbound Unified Model Gateway inference calls, so session/turn baggage from in-process agents shows up in downstream usage telemetry without per-agent wiring.
> 
> On the **Bedrock** path, the existing `before-send` header hook also calls **`_inject_otel_headers`** on each request. On the **OpenAI/Azure** path, the factory always supplies sync and async **`httpx`** clients (default **600s** read / **5s** connect unless a custom sync client’s timeout is reused), attaches a one-time request hook to inject OTel headers, and accepts **`http_async_client`** via **`kwargs`**.
> 
> New unit tests cover OTel inject behavior, idempotent httpx hook registration, and default/custom timeout handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbe5f25b519d984bc4678b0650dc0487ed76d37c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->